### PR TITLE
ZCS-5565 Use enum for general app constants. Remove unused.

### DIFF
--- a/src/java/com/zimbra/graphql/managers/ClassManager.java
+++ b/src/java/com/zimbra/graphql/managers/ClassManager.java
@@ -65,17 +65,23 @@ public class ClassManager {
                         final Configuration config = new Configuration();
 
                         // load the handler class
-                        final Class<?> daoClass = Class.forName(config.getString(GQLConstants.LC_REPOSITORY_CLASS_PREFIX + type));
-                        repository = (IRepository) daoClass.getConstructor(Configuration.class).newInstance(config);
+                        final Class<?> daoClass = Class.forName(config
+                            .getString(GQLConstants.LC_REPOSITORY_CLASS_PREFIX.getValue() + type));
+                        repository = (IRepository) daoClass.getConstructor(Configuration.class)
+                            .newInstance(config);
 
                         // cache the new handler
                         repositoryCache.put(type, repository);
                     } catch (final ClassNotFoundException e) {
                         ZimbraLog.extensions.error("The specified class is not supported: " + type, e);
                         // TODO : exceptions ticket
-                    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
-                            | InvocationTargetException | NoSuchMethodException | SecurityException e) {
-                        ZimbraLog.extensions.error("There was an issue instantiating the repository class for type: " + type, e);
+                    } catch (InstantiationException | IllegalAccessException
+                        | IllegalArgumentException | InvocationTargetException
+                        | NoSuchMethodException | SecurityException e) {
+                        ZimbraLog.extensions.error(
+                            "There was an issue instantiating the repository class for type: "
+                                + type,
+                            e);
                         // TODO : exceptions ticket
                     }
                 }

--- a/src/java/com/zimbra/graphql/resources/GQLExtension.java
+++ b/src/java/com/zimbra/graphql/resources/GQLExtension.java
@@ -21,6 +21,7 @@ import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.extension.ExtensionDispatcherServlet;
 import com.zimbra.cs.extension.ExtensionException;
 import com.zimbra.cs.extension.ZimbraExtension;
+import com.zimbra.graphql.utilities.GQLConstants;
 
 /**
  * GQLExtension class.<br>
@@ -39,12 +40,12 @@ public class GQLExtension implements ZimbraExtension {
 
     @Override
     public String getName() {
-        return "zm-gql";
+        return GQLConstants.API_NAME.getValue();
     }
 
     @Override
     public void init() throws ExtensionException, ServiceException {
-        ZimbraLog.extensions.info("Registering zm-gql");
+        ZimbraLog.extensions.info("Registering %s", getName());
         ExtensionDispatcherServlet.register(this, new GQLServlet());
     }
 

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -32,6 +32,7 @@ import com.zimbra.cs.extension.ExtensionHttpHandler;
 import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
 import com.zimbra.graphql.resolvers.impl.FolderResolver;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.GQLConstants;
 import com.zimbra.graphql.utilities.GQLUtilities;
 
 import graphql.ExecutionInput;
@@ -70,7 +71,7 @@ public class GQLServlet extends ExtensionHttpHandler {
 
     @Override
     public String getPath() {
-        return "/graphql";
+        return GQLConstants.DEFAULT_SERVER_PATH.getValue();
     }
 
     @Override

--- a/src/java/com/zimbra/graphql/utilities/GQLConstants.java
+++ b/src/java/com/zimbra/graphql/utilities/GQLConstants.java
@@ -24,32 +24,45 @@ package com.zimbra.graphql.utilities;
  * @package com.zimbra.graphql.utilities
  * @copyright Copyright © 2018
  */
-public class GQLConstants {
-    public static final String API_NAME = "zm-gql";
-    public static final String ENCODING = "utf-8";
-    public static final String DEFAULT_LOG_LEVEL = "INFO";
-    public static final Integer DEFAULT_SERVER_PORT = 8080;
-    public static final String DEFAULT_SERVER_CONTEXT_PATH = "/*";
+public enum GQLConstants {
 
-    public static final String DEFAULT_HOST_URI_TEMPLATE = "https://%s:443";
+    /**
+     * Service name.
+     */
+    API_NAME("zm-gql"),
 
-    // http related
-    public static final String HEADER_LOCATION = "Location";
-    public static final String QUERY_ERROR = "error";
-    public static final String QUERY_ERROR_MSG = "error_msg";
-    public static final int STATUS_OK = 200;
-    public static final int STATUS_BAD_REQUEST = 400;
+    /**
+     * Default encoding to use.
+     */
+    ENCODING("utf-8"),
 
-    // http query error related
-    public static final String ERROR_ACCESS_DENIED = "access_denied";
-    public static final String ERROR_INVALID_ZM_AUTH_CODE = "invalid_zm_auth_code";
-    public static final String ERROR_INVALID_ZM_AUTH_CODE_MSG = "Invalid or missing Zimbra session.";
-    public static final String ERROR_AUTHENTICATION_ERROR = "authentication_error";
+    /**
+     * Service path.
+     */
+    DEFAULT_SERVER_PATH("/graphql"),
 
-    // LC Related
-    public static final String LC_REPOSITORY_CLASS_PREFIX = "";
-    public static final String LC_GQL_SERVER_CONTEXT_PATH = "gql_server_context_path";
-    public static final String LC_GQL_SERVER_PORT = "gql_server_port";
-    public static final String LC_GQL_LOG_LEVEL = "gql_log_level";
+    /**
+     * TODO: see schema wiring
+     */
+    LC_REPOSITORY_CLASS_PREFIX("");
+
+    /**
+     * Enum value.
+     */
+    private String value;
+
+    /**
+     * @param value The value to set
+     */
+    GQLConstants(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return The value of this instance
+     */
+    public String getValue() {
+        return value;
+    }
 
 }


### PR DESCRIPTION
Small changes.
* Removed unused constants.
* Use enum for remaining.