### PR TITLE
added jackson jars needed to build

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -38,5 +38,9 @@
       <dependency org="log4j" name="log4j" rev="1.2.16" />
       <dependency org="dom4j" name="dom4j" rev="1.5.2" />
       <dependency org="org.json" name="json" rev="20090211" />
+      <!-- jackson jars -->
+      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
added jackson jars without which build was failing.
```
compile:
    [javac] Compiling 34 source files to /mnt/hgfs/pathakc/GitHub/zm-gql/build/classes
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:27: error: package com.fasterxml.jackson.core.type does not exist
    [javac] import com.fasterxml.jackson.core.type.TypeReference;
    [javac]                                       ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:28: error: package com.fasterxml.jackson.databind does not exist
    [javac] import com.fasterxml.jackson.databind.JsonNode;
    [javac]                                      ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:29: error: package com.fasterxml.jackson.databind does not exist
    [javac] import com.fasterxml.jackson.databind.ObjectMapper;
    [javac]                                      ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:57: error: cannot find symbol
    [javac]     protected final ObjectMapper mapper = GQLUtilities.createDefaultMapper();
    [javac]                     ^
    [javac]   symbol:   class ObjectMapper
    [javac]   location: class GQLServlet
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:23: error: package com.fasterxml.jackson.annotation does not exist
    [javac] import com.fasterxml.jackson.annotation.JsonInclude;
    [javac]                                        ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:24: error: package com.fasterxml.jackson.core does not exist
    [javac] import com.fasterxml.jackson.core.JsonParser;
    [javac]                                  ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:25: error: package com.fasterxml.jackson.databind does not exist
    [javac] import com.fasterxml.jackson.databind.DeserializationFeature;
    [javac]                                      ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:26: error: package com.fasterxml.jackson.databind does not exist
    [javac] import com.fasterxml.jackson.databind.ObjectMapper;
    [javac]                                      ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:27: error: package com.fasterxml.jackson.databind does not exist
    [javac] import com.fasterxml.jackson.databind.SerializationFeature;
    [javac]                                      ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:44: error: cannot find symbol
    [javac]     public static ObjectMapper createDefaultMapper() {
    [javac]                   ^
    [javac]   symbol:   class ObjectMapper
    [javac]   location: class GQLUtilities
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:103: error: cannot find symbol
    [javac]         final JsonNode jsonBody = mapper.readTree(GQLUtilities.decodeStream(req.getInputStream(), 0));
    [javac]               ^
    [javac]   symbol:   class JsonNode
    [javac]   location: class GQLServlet
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:107: error: cannot find symbol
    [javac]                 final JsonNode rawQueryNode = jsonBody.get("query");
    [javac]                       ^
    [javac]   symbol:   class JsonNode
    [javac]   location: class GQLServlet
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:114: error: cannot find symbol
    [javac]                 final JsonNode rawOpNameNode = jsonBody.get("operationName");
    [javac]                       ^
    [javac]   symbol:   class JsonNode
    [javac]   location: class GQLServlet
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:121: error: cannot find symbol
    [javac]                 final JsonNode rawVariablesNode = jsonBody.get("variables");
    [javac]                       ^
    [javac]   symbol:   class JsonNode
    [javac]   location: class GQLServlet
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/resources/GQLServlet.java:215: error: cannot find symbol
    [javac]                     new TypeReference<Map<String, Object>>() { });
    [javac]                         ^
    [javac]   symbol:   class TypeReference
    [javac]   location: class GQLServlet
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:45: error: cannot find symbol
    [javac]         final ObjectMapper mapper = new ObjectMapper();
    [javac]               ^
    [javac]   symbol:   class ObjectMapper
    [javac]   location: class GQLUtilities
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:45: error: cannot find symbol
    [javac]         final ObjectMapper mapper = new ObjectMapper();
    [javac]                                         ^
    [javac]   symbol:   class ObjectMapper
    [javac]   location: class GQLUtilities
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:46: error: package JsonInclude does not exist
    [javac]         mapper.setSerializationInclusion(JsonInclude.Include.USE_DEFAULTS);
    [javac]                                                     ^
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:47: error: cannot find symbol
    [javac]         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
    [javac]                          ^
    [javac]   symbol:   variable SerializationFeature
    [javac]   location: class GQLUtilities
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:48: error: cannot find symbol
    [javac]         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
    [javac]                          ^
    [javac]   symbol:   variable DeserializationFeature
    [javac]   location: class GQLUtilities
    [javac] /mnt/hgfs/pathakc/GitHub/zm-gql/src/java/com/zimbra/graphql/utilities/GQLUtilities.java:49: error: package JsonParser does not exist
    [javac]         mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS, true);
    [javac]                                    ^
    [javac] 21 errors

BUILD FAILED
/mnt/hgfs/pathakc/GitHub/zm-zcs/ant-global.xml:284: Compile failed; see the compiler error output for details.

Total time: 7 seconds
```

After adding jackson jars, build is successful.
```
zimbra-jar:
     [echo] building jar from /mnt/hgfs/pathakc/GitHub/zm-gql/build/classes
      [jar] Building jar: /mnt/hgfs/pathakc/GitHub/zm-gql/build/zm-gql-88888888.88888888.6.1531852234.jar

jar:

BUILD SUCCESSFUL
Total time: 2 seconds
```