### PR TITLE
ZCS-5606 Auth resource

### DIFF
--- a/src/java/com/zimbra/graphql/models/AuthContext.java
+++ b/src/java/com/zimbra/graphql/models/AuthContext.java
@@ -16,6 +16,9 @@
  */
 package com.zimbra.graphql.models;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import com.zimbra.cs.account.Account;
 import com.zimbra.cs.account.AuthToken;
 import com.zimbra.cs.mailbox.OperationContext;
@@ -46,6 +49,16 @@ public class AuthContext {
      * Request operation context.
      */
     protected OperationContext operationContext;
+
+    /**
+     * Raw http request.
+     */
+    protected HttpServletRequest rawRequest;
+
+    /**
+     * Raw http response.
+     */
+    protected HttpServletResponse rawResponse;
 
     @GraphQLQuery(name = "authToken", description = "The authorization token.")
     public AuthToken getAuthToken() {
@@ -81,6 +94,30 @@ public class AuthContext {
      */
     public void setOperationContext(OperationContext operationContext) {
         this.operationContext = operationContext;
+    }
+
+    @GraphQLQuery(name = "rawRequest", description = "The raw http request.")
+    public HttpServletRequest getRawRequest() {
+        return rawRequest;
+    }
+
+    /**
+     * @param rawRequest The raw http request to set
+     */
+    public void setRawRequest(HttpServletRequest rawRequest) {
+        this.rawRequest = rawRequest;
+    }
+
+    @GraphQLQuery(name = "rawResponse", description = "The raw http response.")
+    public HttpServletResponse getRawResponse() {
+        return rawResponse;
+    }
+
+    /**
+     * @param rawResponse The raw http response to set
+     */
+    public void setRawResponse(HttpServletResponse rawResponse) {
+        this.rawResponse = rawResponse;
     }
 
 }

--- a/src/java/com/zimbra/graphql/models/inputs/GQLAuthRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLAuthRequestInput.java
@@ -1,0 +1,214 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.inputs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zimbra.soap.account.type.Attr;
+import com.zimbra.soap.account.type.AuthToken;
+import com.zimbra.soap.account.type.PreAuth;
+import com.zimbra.soap.account.type.Pref;
+import com.zimbra.soap.type.AccountSelector;
+
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLAuthRequestInput class.<br>
+ * Contains auth request properties.
+ * @see com.zimbra.soap.account.message.AuthRequest
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.inputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name="AuthRequest", description="Input for authentication request.")
+public class GQLAuthRequestInput {
+
+    protected AccountSelector account;
+    protected String password;
+    protected PreAuth preauthToken;
+    protected AuthToken authToken;
+    protected String jwtAuthToken;
+    protected String trustedDeviceToken;
+    protected String tokenType;
+    protected String receoveryCode;
+    protected String twoFactorCode;
+    protected String virtualHost;
+    protected String deviceId;
+    protected Boolean doPersistCookie;
+    protected Boolean isCsrfSupported;
+    protected Boolean isDeviceTrusted;
+    protected Boolean doGenerateDeviceId;
+    protected List<Pref> prefs = new ArrayList<Pref>();
+    protected List<Attr> attrs = new ArrayList<Attr>();
+
+    public AccountSelector getAccount() {
+        return account;
+    }
+
+    @GraphQLInputField(name="account", description="Specifies the account to authenticate against")
+    public void setAccount(AccountSelector account) {
+        this.account = account;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @GraphQLInputField(name="password", description="Password to use in conjunction with an account")
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public PreAuth getPreauthToken() {
+        return preauthToken;
+    }
+
+    @GraphQLInputField(name="preauthToken", description="<preauth> is an alternative to <account>. See preauth.txt")
+    public void setPreauthToken(PreAuth preauthToken) {
+        this.preauthToken = preauthToken;
+    }
+
+    public AuthToken getAuthToken() {
+        return authToken;
+    }
+
+    @GraphQLInputField(name="authToken", description="An authToken can be passed instead of account/password/preauth to validate an existing auth token.")
+    public void setAuthToken(AuthToken authToken) {
+        this.authToken = authToken;
+    }
+
+    public String getJwtAuthToken() {
+        return jwtAuthToken;
+    }
+
+    @GraphQLInputField(name="jwtAuthToken", description="JWT auth token")
+    public void setJwtAuthToken(String jwtAuthToken) {
+        this.jwtAuthToken = jwtAuthToken;
+    }
+
+    public String getTrustedDeviceToken() {
+        return trustedDeviceToken;
+    }
+
+    @GraphQLInputField(name="trustedDeviceToken", description="Whether the client represents a trusted device")
+    public void setTrustedDeviceToken(String trustedDeviceToken) {
+        this.trustedDeviceToken = trustedDeviceToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    @GraphQLInputField(name="tokenType", description="Type of token to be returned, it can be auth or jwt")
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    public String getReceoveryCode() {
+        return receoveryCode;
+    }
+
+    @GraphQLInputField(name="recoveryCode", description="RecoveryCode to use in conjunction with an account in case of forgot password flow.")
+    public void setReceoveryCode(String receoveryCode) {
+        this.receoveryCode = receoveryCode;
+    }
+
+    public String getTwoFactorCode() {
+        return twoFactorCode;
+    }
+
+    @GraphQLInputField(name="twoFactorCode", description="The TOTP code used for two-factor authentication")
+    public void setTwoFactorCode(String twoFactorCode) {
+        this.twoFactorCode = twoFactorCode;
+    }
+
+    public String getVirtualHost() {
+        return virtualHost;
+    }
+
+    @GraphQLInputField(name="virtualHost", description="If specified (in conjunction with by=\"name\"), virtual-host is used to determine the domain of the account name, if it does not include a domain component.")
+    public void setVirtualHost(String virtualHost) {
+        this.virtualHost = virtualHost;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    @GraphQLInputField(name="deviceId", description="Unique device identifier; used to verify trusted mobile devices")
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public Boolean getDoPersistCookie() {
+        return doPersistCookie;
+    }
+
+    @GraphQLInputField(name="doPersistCookie", description="Denotes whether the auth token cookie in the response should be persisted when the browser exits")
+    public void setDoPersistCookie(Boolean doPersistCookie) {
+        this.doPersistCookie = doPersistCookie;
+    }
+
+    public Boolean getIsCsrfSupported() {
+        return isCsrfSupported;
+    }
+
+    @GraphQLInputField(name="isCsrfSupported", description="Denotes whether the client supports CSRF token")
+    public void setIsCsrfSupported(Boolean isCsrfSupported) {
+        this.isCsrfSupported = isCsrfSupported;
+    }
+
+    public Boolean getIsDeviceTrusted() {
+        return isDeviceTrusted;
+    }
+
+    @GraphQLInputField(name="isDeviceTrusted", description="Denotes whether the client represents a trusted device")
+    public void setIsDeviceTrusted(Boolean isDeviceTrusted) {
+        this.isDeviceTrusted = isDeviceTrusted;
+    }
+
+    public Boolean getDoGenerateDeviceId() {
+        return doGenerateDeviceId;
+    }
+
+    @GraphQLInputField(name="doGenerateDeviceId", description="Denotes whether to generate a device id")
+    public void setDoGenerateDeviceId(Boolean doGenerateDeviceId) {
+        this.doGenerateDeviceId = doGenerateDeviceId;
+    }
+
+    public List<Pref> getPrefs() {
+        return prefs;
+    }
+
+    @GraphQLInputField(name="prefs", description="Requested preference settings")
+    public void setPrefs(List<Pref> prefs) {
+        this.prefs = prefs;
+    }
+
+    public List<Attr> getAttrs() {
+        return attrs;
+    }
+
+    @GraphQLInputField(name="attrs", description="Requested attribute settings. Only attributes that are allowed will be returned")
+    public void setAttrs(List<Attr> attrs) {
+        this.attrs = attrs;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAuthRepository.java
@@ -1,0 +1,102 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.account.Auth;
+import com.zimbra.graphql.models.AuthContext;
+import com.zimbra.graphql.models.inputs.GQLAuthRequestInput;
+import com.zimbra.graphql.repositories.IRepository;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.account.message.AuthRequest;
+import com.zimbra.soap.account.message.AuthResponse;
+
+/**
+ * The ZXMLAuthRepository class.<br>
+ * Contains XML document based data access methods for auth.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.repositories.impl
+ * @copyright Copyright © 2018
+ */
+public class ZXMLAuthRepository extends ZXMLRepository implements IRepository {
+
+    /**
+     * The auth document handler.
+     */
+    protected final Auth authHandler;
+
+    /**
+     * Creates an instance with default document handlers.
+     */
+    public ZXMLAuthRepository() {
+        this(new Auth());
+    }
+
+    /**
+     * Creates an instance with specified handlers.
+     *
+     * @param authHandler The auth handler
+     */
+    public ZXMLAuthRepository(Auth authHandler) {
+        super();
+        this.authHandler = authHandler;
+    }
+
+    /**
+     * Performs an auth request with given properties.
+     *
+     * @param authContext The request context
+     * @param authInput Auth properties
+     * @return The auth response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public AuthResponse authenticate(AuthContext authContext, GQLAuthRequestInput authInput)
+        throws ServiceException {
+        final AuthRequest req = new AuthRequest();
+        req.setAccount(authInput.getAccount());
+        req.setPassword(authInput.getPassword());
+        req.setPreauth(authInput.getPreauthToken());
+        req.setAuthToken(authInput.getAuthToken());
+        req.setJwtToken(authInput.getJwtAuthToken());
+        req.setTrustedDeviceToken(authInput.getTrustedDeviceToken());
+        req.setTokenType(authInput.getTokenType());
+        req.setRecoveryCode(authInput.getReceoveryCode());
+        req.setTwoFactorCode(authInput.getTwoFactorCode());
+        req.setVirtualHost(authInput.getVirtualHost());
+        req.setDeviceId(authInput.getDeviceId());
+        req.setPersistAuthTokenCookie(authInput.getDoPersistCookie());
+        req.setCsrfSupported(authInput.getIsCsrfSupported());
+        req.setDeviceTrusted(authInput.getIsDeviceTrusted());
+        req.setGenerateDeviceId(authInput.getDoGenerateDeviceId());
+        req.setPrefs(authInput.getPrefs());
+        req.setAttrs(authInput.getAttrs());
+        // execute
+        final Element response = XMLDocumentUtilities.executeDocumentAsGuest(
+            authHandler,
+            XMLDocumentUtilities.toElement(req),
+            authContext);
+        AuthResponse zAuthResponse = null;
+        if (response != null) {
+            zAuthResponse = XMLDocumentUtilities
+                .fromElement(response, AuthResponse.class);
+        }
+        return zAuthResponse;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLItemRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLItemRepository.java
@@ -46,6 +46,7 @@ public class ZXMLItemRepository extends ZXMLRepository implements IRepository {
      * @param actionHandler The document handler for this instance
      */
     public ZXMLItemRepository(ItemAction actionHandler) {
+        super();
         this.actionHandler = actionHandler;
     }
 

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLRepository.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.graphql.repositories.impl;
 
+import com.zimbra.common.util.ZimbraLog;
+
 /**
  * The ZXMLRepository class.
  *
@@ -24,5 +26,9 @@ package com.zimbra.graphql.repositories.impl;
  * @copyright Copyright © 2018
  */
 public class ZXMLRepository {
+
+    public  ZXMLRepository() {
+        ZimbraLog.extensions.info("Loading %s . . .", this.getClass().getName());
+    }
 
 }

--- a/src/java/com/zimbra/graphql/resolvers/impl/AuthResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AuthResolver.java
@@ -1,0 +1,58 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resolvers.impl;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.graphql.models.AuthContext;
+import com.zimbra.graphql.models.inputs.GQLAuthRequestInput;
+import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
+import com.zimbra.soap.account.message.AuthResponse;
+
+import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+
+/**
+ * The AuthResolver class.<br>
+ * Contains auth schema resources.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.resolvers.impl
+ * @copyright Copyright © 2018
+ */
+public class AuthResolver {
+
+    protected ZXMLAuthRepository authRepository = null;
+
+    /**
+     * Creates an instance with specified auth repository.
+     *
+     * @param authRepository The auth repository
+     */
+    public AuthResolver(ZXMLAuthRepository authRepository) {
+        this.authRepository = authRepository;
+    }
+
+    @GraphQLMutation(description = "Authenticate for an account.")
+    public AuthResponse authenticate(
+        @GraphQLNonNull @GraphQLArgument(name = "authInput") GQLAuthRequestInput authRequestInput,
+        @GraphQLRootContext AuthContext context) throws ServiceException {
+        return authRepository.authenticate(context, authRequestInput);
+    }
+
+}

--- a/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
@@ -21,9 +21,11 @@ import java.util.Map;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.graphql.models.AuthContext;
 import com.zimbra.soap.DocumentHandler;
 import com.zimbra.soap.JaxbUtil;
 import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.SoapServlet;
 import com.zimbra.soap.ZimbraSoapContext;
 
 /**
@@ -35,6 +37,26 @@ import com.zimbra.soap.ZimbraSoapContext;
  * @copyright Copyright © 2018
  */
 public class XMLDocumentUtilities {
+
+    /**
+     * Executes a given request on a document handler without
+     * validating auth credentials.
+     *
+     * @param handler The handler to handle the request
+     * @param request The request to execute
+     * @param actxt The graphql context for the request
+     * @return The document response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public static Element executeDocumentAsGuest(DocumentHandler handler, Element request, AuthContext actxt)
+        throws ServiceException {
+        final Map<String, Object> context = new HashMap<String, Object>();
+        context.put(SoapEngine.ZIMBRA_CONTEXT,
+            GQLAuthUtilities.getGuestZimbraSoapContext(request.getQName(), handler));
+        context.put(SoapServlet.SERVLET_REQUEST, actxt.getRawRequest());
+        context.put(SoapServlet.SERVLET_RESPONSE, actxt.getRawResponse());
+        return handler.handle(request, context);
+    }
 
     /**
      * Executes a given request on a document handler.


### PR DESCRIPTION
* Support Auth document.
* Use local request input class as example for further implementations.
* Add request/response support to `AuthContext` so handlers that require it for header modification have access.
  * We may want to consider using a dummy http response, and relaying the headers onto the real ones in `zm-gql`, rather than giving the handlers control over this. (will implement if it makes sense to do so in the future)
* zsc without authToken and account for auth.

See associated PR Zimbra/zm-mailbox#706.

Looking for feedback.
