### PR TITLE
ZCS-5767 Front end exception handling and debugging

### DIFF
--- a/src/java/com/zimbra/graphql/errors/GQLError.java
+++ b/src/java/com/zimbra/graphql/errors/GQLError.java
@@ -1,0 +1,81 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.errors;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+
+import graphql.ErrorType;
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+
+/**
+ * The GQLError class.<br>
+ * GraphQLError Wrapper for exceptions.<br>
+ * Used to generate errors to spec from exceptions not handled
+ * by query execution.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.errors
+ * @copyright Copyright © 2018
+ */
+public class GQLError implements GraphQLError {
+
+    /**
+     * The error message for this error response.
+     */
+    protected String message = "";
+
+    /**
+     * The exception associated with this error.
+     */
+    protected Exception exception;
+
+    /**
+     * Generates the message.
+     *
+     * @param e The exception associated with this error
+     */
+    public GQLError(Exception e) {
+        this.exception = e;
+        if (e instanceof ServiceException) {
+            this.message += ((ServiceException) e).getCode() + " : ";
+        }
+        this.message += e.getMessage();
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public List<SourceLocation> getLocations() {
+        return null;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        if (exception instanceof IOException) {
+            return ErrorType.InvalidSyntax;
+        }
+        return ErrorType.ValidationError;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/utilities/GQLAuthUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/GQLAuthUtilities.java
@@ -65,6 +65,7 @@ public class GQLAuthUtilities {
     public static AuthContext buildContext(HttpServletRequest req, HttpServletResponse resp) {
         AuthToken token = null;
         Account account = null;
+        ZimbraLog.extensions.debug("Building request context.");
         try {
             final Cookie [] cookies = req.getCookies();
             final Map<String, String> headers = new HashMap<String, String>();
@@ -164,6 +165,7 @@ public class GQLAuthUtilities {
     protected static Account getAccount(AuthToken authToken) throws ServiceException {
         Account account = null;
         if (authToken != null) {
+            ZimbraLog.extensions.debug("Validating request auth credentials.");
             if (authToken.isZimbraUser()) {
                 if (!authToken.isRegistered()) {
                     throw ServiceException.PERM_DENIED(HttpServletResponse.SC_UNAUTHORIZED + ": "
@@ -244,6 +246,7 @@ public class GQLAuthUtilities {
             return new ZimbraSoapContext(octxt.getAuthToken(), account.getId(), SoapProtocol.Soap12,
                 SoapProtocol.Soap12);
         }
+        ZimbraLog.extensions.debug("Request could not be authenticated.");
         throw ServiceException.PERM_DENIED("Request could not be authenticated.");
     }
 


### PR DESCRIPTION
* Added basic logging for front end (prior to gql query execution).
* Added temp exception handling for previously ignored exceptions. (json reading, missing operation name, etc)
  * Can improve on this in full exception handling ticket when we decide to change the exception structure for both frontend and query errors.