### PR TITLE
ZCS-5607 Implementing CreateSearchFolder API in GraphQL

### DIFF
--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
@@ -211,7 +211,7 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
      * @return A list of search folders
      * @throws ServiceException If there are issues executing the document
      */
-    public List<SearchFolder> getSearchFolder(OperationContext octxt, Account account)
+    public List<SearchFolder> searchFolderGet(OperationContext octxt, Account account)
             throws ServiceException {
         // execute
         final GetSearchFolderRequest req = new GetSearchFolderRequest();
@@ -237,7 +237,7 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
      * @return The newly created folder
      * @throws ServiceException If there are issues executing the document
      */
-    public SearchFolder createSearchFolder(OperationContext octxt, Account account, NewSearchFolderSpec searchFolder)
+    public SearchFolder searchFolderCreate(OperationContext octxt, Account account, NewSearchFolderSpec searchFolder)
             throws ServiceException {
         // execute
         final CreateSearchFolderRequest req = new CreateSearchFolderRequest(searchFolder);
@@ -260,7 +260,7 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
      * @return The modified search folder
      * @throws ServiceException If there are issues executing the document
      */
-    public SearchFolder modifySearchFolder(OperationContext octxt, Account account, ModifySearchFolderSpec searchFolder)
+    public SearchFolder searchFolderModify(OperationContext octxt, Account account, ModifySearchFolderSpec searchFolder)
             throws ServiceException {
         // execute
         final ModifySearchFolderRequest req = new ModifySearchFolderRequest(searchFolder);

--- a/src/java/com/zimbra/graphql/resolvers/impl/FolderResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/FolderResolver.java
@@ -86,23 +86,23 @@ public class FolderResolver {
     }
 
     @GraphQLQuery(description = "Retrieve search folders for given user")
-    public List<SearchFolder> searchFolder(@GraphQLRootContext AuthContext context) throws ServiceException {
-        return folderRepository.getSearchFolder(context.getOperationContext(), context.getAccount());
+    public List<SearchFolder> searchFolderGet(@GraphQLRootContext AuthContext context) throws ServiceException {
+        return folderRepository.searchFolderGet(context.getOperationContext(), context.getAccount());
     }
 
     @GraphQLMutation(description = "Create a search folder with given properties.")
-    public SearchFolder createSearchFolder(
+    public SearchFolder searchFolderCreate(
         @GraphQLNonNull @GraphQLArgument(name = "searchFolder") NewSearchFolderSpec searchFolder,
         @GraphQLRootContext AuthContext context) throws ServiceException {
-        return folderRepository.createSearchFolder(context.getOperationContext(), context.getAccount(),
+        return folderRepository.searchFolderCreate(context.getOperationContext(), context.getAccount(),
             searchFolder);
     }
 
     @GraphQLMutation(description = "Modify existing search folder with given properties.")
-    public SearchFolder modifySearchFolder(
+    public SearchFolder searchFolderModify(
         @GraphQLNonNull @GraphQLArgument(name = "searchFolder") ModifySearchFolderSpec searchFolder,
         @GraphQLRootContext AuthContext context) throws ServiceException {
-        return folderRepository.modifySearchFolder(context.getOperationContext(), context.getAccount(),
+        return folderRepository.searchFolderModify(context.getOperationContext(), context.getAccount(),
             searchFolder);
     }
 }


### PR DESCRIPTION
**Problem:** Implement CreateSearchFolder, GetSearchFolder and ModifySearchFolder api in gql

**Fix:**
- Created query for GetSearchFolder and mutation for CreateSearchFolder and ModifySearchFolder
- Added required annotations for all 3 apis
- Made required changes in repository and resolver classes

**Testing done:**
- Tested all 3 apis manually using graphiql client
- Docs for the same can be viewed on graphiql

**Testing to be done by QA:**
- Test all 3 apis manually with all different combinations of input
- Automate the same

**Linked PR:**
https://github.com/Zimbra/zm-mailbox/pull/707