### PR TITLE
ZCS-5606 Always return request and response with auth context.

### DIFF
--- a/src/java/com/zimbra/graphql/utilities/GQLAuthUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/GQLAuthUtilities.java
@@ -65,6 +65,9 @@ public class GQLAuthUtilities {
     public static AuthContext buildContext(HttpServletRequest req, HttpServletResponse resp) {
         AuthToken token = null;
         Account account = null;
+        final AuthContext context = new AuthContext();
+        context.setRawRequest(req);
+        context.setRawResponse(resp);
         ZimbraLog.extensions.debug("Building request context.");
         try {
             final Cookie [] cookies = req.getCookies();
@@ -75,14 +78,11 @@ public class GQLAuthUtilities {
         } catch (final ServiceException e) {
             ZimbraLog.extensions.debug("Could not authenticate the user.");
             // if an exception occurred, auth was present but invalid
-            // return an empty auth context
-            return new AuthContext();
+            // return an auth context with just the request, and response
+            return context;
         }
-        final AuthContext context = new AuthContext();
         context.setAuthToken(token);
         context.setAccount(account);
-        context.setRawRequest(req);
-        context.setRawResponse(resp);
         context.setOperationContext(getOperationContext(req, token));
         return context;
     }


### PR DESCRIPTION
If an expired auth token is present in cookies, it will result in an error when trying to auth due to missing request/response from the empty auth context.

* Set request and response on auth context at all times

*Testing Done*
* Add a Cookie header with an **expired** ZM_AUTH_TOKEN to any auth request
* Attempt to login
  * Expected: A proper auth response
  * Actual: An authenticate error