### PR TITLE
ZCS-5351 Implement API for user account info

### DIFF
--- a/src/java/com/zimbra/graphql/models/outputs/AccountInfo.java
+++ b/src/java/com/zimbra/graphql/models/outputs/AccountInfo.java
@@ -1,0 +1,180 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.graphql.models.outputs;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
+import com.zimbra.soap.type.NamedValue;
+
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+@GraphQLType(name=GqlConstants.ACCOUNT_INFO, description="account info response data")
+public class AccountInfo {
+    @GraphQLNonNull
+    @GraphQLQuery(name=GqlConstants.NAME)
+    private String name;
+    @GraphQLNonNull
+    @GraphQLQuery(name=GqlConstants.ATTRS, description="account attributes")
+    private List<NamedValue> attrs = Lists.newArrayList();
+    @GraphQLQuery(name=GqlConstants.SOAP_URL, description="soap url")
+    private String soapURL;
+    @GraphQLQuery(name=GqlConstants.PUBLIC_URL, description="public url")
+    private String publicURL;
+    @GraphQLQuery(name=GqlConstants.CHANGE_PASSWORD_URL, description="change password url")
+    private String changePasswordURL;
+    @GraphQLQuery(name=GqlConstants.COMMUNITY_URL, description="community url")
+    private String communityURL;
+    @GraphQLQuery(name=GqlConstants.ADMIN_URL, description="admin url")
+    private String adminURL;
+    @GraphQLQuery(name=GqlConstants.BOSH_URL, description="bosh url")
+    private String boshURL;
+
+    /*
+     * default constructor
+     */
+    public AccountInfo() {
+        this.name = null;
+        this.attrs = null;
+    }
+
+    /**
+     * @param name
+     * @param attrs
+     */
+    public AccountInfo(String name, List<NamedValue> attrs) {
+        this.name = name;
+        this.attrs = attrs;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the attrs
+     */
+    public List<NamedValue> getAttrs() {
+        return attrs;
+    }
+
+    /**
+     * @param attrs the attrs to set
+     */
+    public void setAttrs(List<NamedValue> attrs) {
+        this.attrs = attrs;
+    }
+
+    /**
+     * @return the soapURL
+     */
+    public String getSoapURL() {
+        return soapURL;
+    }
+
+    /**
+     * @param soapURL the soapURL to set
+     */
+    public void setSoapURL(String soapURL) {
+        this.soapURL = soapURL;
+    }
+
+    /**
+     * @return the publicURL
+     */
+    public String getPublicURL() {
+        return publicURL;
+    }
+
+    /**
+     * @param publicURL the publicURL to set
+     */
+    public void setPublicURL(String publicURL) {
+        this.publicURL = publicURL;
+    }
+
+    /**
+     * @return the changePasswordURL
+     */
+    public String getChangePasswordURL() {
+        return changePasswordURL;
+    }
+
+    /**
+     * @param changePasswordURL the changePasswordURL to set
+     */
+    public void setChangePasswordURL(String changePasswordURL) {
+        this.changePasswordURL = changePasswordURL;
+    }
+
+    /**
+     * @return the communityURL
+     */
+    public String getCommunityURL() {
+        return communityURL;
+    }
+
+    /**
+     * @param communityURL the communityURL to set
+     */
+    public void setCommunityURL(String communityURL) {
+        this.communityURL = communityURL;
+    }
+
+    /**
+     * @return the adminURL
+     */
+    public String getAdminURL() {
+        return adminURL;
+    }
+
+    /**
+     * @param adminURL the adminURL to set
+     */
+    public void setAdminURL(String adminURL) {
+        this.adminURL = adminURL;
+    }
+
+    /**
+     * @return the boshURL
+     */
+    public String getBoshURL() {
+        return boshURL;
+    }
+
+    /**
+     * @param boshURL the boshURL to set
+     */
+    public void setBoshURL(String boshURL) {
+        this.boshURL = boshURL;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
@@ -1,0 +1,84 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+
+package com.zimbra.graphql.repositories.impl;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.account.EndSession;
+import com.zimbra.cs.service.account.GetAccountInfo;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.outputs.AccountInfo;
+import com.zimbra.graphql.repositories.IRepository;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.JaxbUtil;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.account.message.EndSessionRequest;
+import com.zimbra.soap.account.message.GetAccountInfoRequest;
+import com.zimbra.soap.account.message.GetAccountInfoResponse;
+import com.zimbra.soap.type.AccountBy;
+import com.zimbra.soap.type.AccountSelector;
+
+public class ZXMLAccountRepository extends ZXMLRepository implements IRepository {
+    protected final GetAccountInfo accountInfoHandler;
+    protected final EndSession endSessionHandler;
+
+    public ZXMLAccountRepository() {
+        accountInfoHandler = new GetAccountInfo();
+        endSessionHandler = new EndSession();
+    }
+
+    public ZXMLAccountRepository(GetAccountInfo accountInfoHandler, EndSession endSessionHandler) {
+        this.accountInfoHandler = accountInfoHandler;
+        this.endSessionHandler = endSessionHandler;
+    }
+
+    public AccountInfo accountInfoGet(RequestContext rctxt) throws ServiceException{
+        AccountInfo info = new AccountInfo();
+        ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        AccountSelector selector = new AccountSelector(AccountBy.id, zsc.getAuthToken().getAccountId());
+        GetAccountInfoRequest request = new GetAccountInfoRequest(selector);
+        final Element response = XMLDocumentUtilities.executeDocument(
+                accountInfoHandler, zsc,
+                XMLDocumentUtilities.toElement(request));
+        if (response != null) {
+            GetAccountInfoResponse resp = JaxbUtil.elementToJaxb(response, GetAccountInfoResponse.class);
+            info.setName(resp.getName());
+            info.setAttrs(resp.getAttrs());
+            info.setSoapURL(resp.getSoapURL());
+            info.setPublicURL(resp.getPublicURL());
+            info.setCommunityURL(resp.getCommunityURL());
+            info.setChangePasswordURL(resp.getChangePasswordURL());
+            info.setAdminURL(resp.getAdminURL());
+            info.setBoshURL(resp.getBoshURL());
+        }
+        return info;
+    }
+
+    public void accountEndSession(RequestContext rctxt, Boolean clearCookies) throws ServiceException {
+        ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        EndSessionRequest request = new EndSessionRequest();
+        request.setLogOff(clearCookies);
+        final Element response = XMLDocumentUtilities.executeDocument(
+                endSessionHandler, zsc,
+                XMLDocumentUtilities.toElement(request));
+        if (response == null) {
+            throw ServiceException.FAILURE("EndSessionRequest failed", null);
+        }
+    }
+}

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -1,0 +1,63 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resolvers.impl;
+
+import com.zimbra.common.gql.GqlConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.outputs.AccountInfo;
+import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
+
+import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+
+/**
+ * The AccountResolver class.<br>
+ * Contains folder schema resources.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.resolvers.impl
+ * @copyright Copyright © 2018
+ */
+public class AccountResolver {
+
+    protected ZXMLAccountRepository accountRepository = null;
+
+    /**
+     * Creates an instance with specified account repository.
+     *
+     * @param accountRepository The account repository
+     */
+    public AccountResolver(ZXMLAccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    @GraphQLQuery(description = "Retrieve account info")
+    public AccountInfo accountInfoGet(@GraphQLRootContext RequestContext context) throws ServiceException {
+        return accountRepository.accountInfoGet(context);
+    }
+
+    @GraphQLMutation(description="logout/end session for current user")
+    public void accountEndSession(
+            @GraphQLRootContext RequestContext context,
+            @GraphQLArgument(name=GqlConstants.CLEAR_COOKIES, description="clear cookies with end session")
+            boolean clearCookies) throws ServiceException {
+        accountRepository.accountEndSession(context, clearCookies);
+    }
+}

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -35,8 +35,10 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.extension.ExtensionHttpHandler;
 import com.zimbra.graphql.errors.GQLError;
+import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
+import com.zimbra.graphql.resolvers.impl.AccountResolver;
 import com.zimbra.graphql.resolvers.impl.AuthResolver;
 import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
 import com.zimbra.graphql.resolvers.impl.FolderResolver;
@@ -224,6 +226,7 @@ public class GQLServlet extends ExtensionHttpHandler {
         final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository());
         final FolderResolver folderResolver = new FolderResolver(new ZXMLFolderRepository());
         final SearchResolver searchResolver = new SearchResolver(new ZXMLSearchRepository());
+        final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
         ZimbraLog.extensions.info("Generating schema with loaded resolvers . . .");
         return new GraphQLSchemaGenerator()
             .withBasePackages(
@@ -232,7 +235,8 @@ public class GQLServlet extends ExtensionHttpHandler {
             .withOperationsFromSingletons(
                 authResolver,
                 folderResolver,
-                searchResolver
+                searchResolver,
+                accountResolver
             ).generate();
     }
 


### PR DESCRIPTION
**Problem:** Write graphql api for GetAccountInfo and EndSession soap apis

**Fix:**
- Created both apis

**Testing done:**
- Tested both apis maually
```
query{
  accountInfoGet{
    name
    attrs {
      name
      value
    }
    soapURL
    publicURL
    communityURL
    changePasswordURL
    adminURL
    boshURL
  }
}
```
```
mutation{
  accountEndSession(clearCookies: true)
}
```

**Testing needed by QA:**
- test both the apis
- write automation for the same

**Linked PR:**
https://github.com/Zimbra/zm-mailbox/pull/716