### PR TITLE
Clean up docblocks, rename folder mutations.

### DIFF
--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
@@ -88,18 +88,14 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
      * Creates an instance with default document handlers.
      */
     public ZXMLFolderRepository() {
-        super(new FolderAction());
-        createFolderHandler = new CreateFolder();
-        getFolderHandler = new GetFolder();
-        createSearchFolderHandler = new CreateSearchFolder();
-        getSearchFolderHandler = new GetSearchFolder();
-        modifySearchFolderHandler = new ModifySearchFolder();
+        this(new FolderAction(), new CreateFolder(), new GetFolder(), new CreateSearchFolder(),
+            new GetSearchFolder(), new ModifySearchFolder());
     }
 
     /**
      * Creates an instance with specified handlers.
      *
-     * @param actionHandler The item action handler.
+     * @param actionHandler The item action handler
      * @param createHandler The create folder handler
      * @param getHandler The get folder handler
      * @param createSearchFolderHandler The create search folder handler
@@ -127,10 +123,10 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
      * @param depth Filter subfolder tree depth
      * @param traverseMountpoints Whether or not to traverse one level of mountpoints
      * @param getFolder The primary folder identifiers
-     * @return Fetch reuslts
+     * @return Fetch folder results
      * @throws ServiceException If there are issues executing the document
      */
-    public Folder getFolder(RequestContext rctxt, Boolean visible,
+    public Folder folder(RequestContext rctxt, Boolean visible,
         Boolean needGranteeName, Folder.View view, Integer depth, Boolean traverseMountpoints,
         GetFolderSpec getFolder) throws ServiceException {
         // get auth context

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -29,7 +29,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 
 /**
  * The AccountResolver class.<br>
- * Contains folder schema resources.
+ * Contains account schema resources.
  *
  * @author Zimbra API Team
  * @package com.zimbra.graphql.resolvers.impl
@@ -49,15 +49,15 @@ public class AccountResolver {
     }
 
     @GraphQLQuery(description = "Retrieve account info")
-    public AccountInfo accountInfoGet(@GraphQLRootContext RequestContext context) throws ServiceException {
+    public AccountInfo accountInfoGet(@GraphQLRootContext RequestContext context)
+        throws ServiceException {
         return accountRepository.accountInfoGet(context);
     }
 
-    @GraphQLMutation(description="logout/end session for current user")
+    @GraphQLMutation(description="Logout/end session for current user")
     public void accountEndSession(
-            @GraphQLRootContext RequestContext context,
-            @GraphQLArgument(name=GqlConstants.CLEAR_COOKIES, description="clear cookies with end session")
-            boolean clearCookies) throws ServiceException {
+        @GraphQLArgument(name = GqlConstants.CLEAR_COOKIES, description = "Denotes whether to clear cookies") boolean clearCookies,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
         accountRepository.accountEndSession(context, clearCookies);
     }
 }

--- a/src/java/com/zimbra/graphql/resolvers/impl/FolderResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/FolderResolver.java
@@ -66,19 +66,19 @@ public class FolderResolver {
         @GraphQLArgument(name = "traverseMountpoints") Boolean traverseMountpoints,
         @GraphQLArgument(name = "getFolder") GetFolderSpec getFolder,
         @GraphQLRootContext RequestContext context) throws ServiceException {
-        return folderRepository.getFolder(context, visible, needGranteeName, view, depth,
+        return folderRepository.folder(context, visible, needGranteeName, view, depth,
             traverseMountpoints, getFolder);
     }
 
     @GraphQLMutation(description = "Create a folder with given properties.")
-    public Folder createFolder(
+    public Folder folderCreate(
         @GraphQLNonNull @GraphQLArgument(name = "folder") NewFolderSpec folder,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return folderRepository.createFolder(context, folder);
     }
 
     @GraphQLMutation(description = "Handles a folder action request.")
-    public FolderActionResult action(
+    public FolderActionResult folderAction(
         @GraphQLNonNull @GraphQLArgument(name = "input") FolderActionSelector input,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return folderRepository.action(context, input);

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -38,9 +38,9 @@ import com.zimbra.graphql.errors.GQLError;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
 import com.zimbra.graphql.resolvers.impl.AccountResolver;
 import com.zimbra.graphql.resolvers.impl.AuthResolver;
-import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
 import com.zimbra.graphql.resolvers.impl.FolderResolver;
 import com.zimbra.graphql.resolvers.impl.SearchResolver;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
@@ -223,20 +223,20 @@ public class GQLServlet extends ExtensionHttpHandler {
      * @return A wired schema
      */
     protected GraphQLSchema buildSchema() {
+        final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
         final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository());
         final FolderResolver folderResolver = new FolderResolver(new ZXMLFolderRepository());
         final SearchResolver searchResolver = new SearchResolver(new ZXMLSearchRepository());
-        final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
         ZimbraLog.extensions.info("Generating schema with loaded resolvers . . .");
         return new GraphQLSchemaGenerator()
             .withBasePackages(
                 "com.zimbra.graphql.models",
                 "com.zimbra.soap")
             .withOperationsFromSingletons(
+                accountResolver,
                 authResolver,
                 folderResolver,
-                searchResolver,
-                accountResolver
+                searchResolver
             ).generate();
     }
 


### PR DESCRIPTION
* Updated docblocks where needed
* Renamed folder mutations for typeAction
* Fix constructor super call for account repository
* Don't use jaxbutil directly in account repository to ease eventual unit tests
* Alphabetical resolver/repo creation in schema build.

API usage change to normal folder mutation names only.
