### PR TITLE
ZCS-4165 Implement API for contacts.

### DIFF
--- a/src/java/com/zimbra/graphql/models/inputs/GQLGetContactsRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLGetContactsRequestInput.java
@@ -1,0 +1,164 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.inputs;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.zimbra.soap.type.AttributeName;
+import com.zimbra.soap.type.Id;
+
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLContactsRequestInput class.<br>
+ * Contains contacts request properties.
+ * @see com.zimbra.soap.mail.message.GetContactsRequest
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.inputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name="GetContactsRequest", description="Input for get contacts request.")
+public class GQLGetContactsRequestInput {
+
+    private String folderId;
+    private String sortBy;
+    private Boolean doSync;
+    private Boolean doDerefGroupMember;
+    private Boolean doGetMemberOf;
+    private Boolean doGetHiddenAttrs;
+    private Boolean doGetCertInfo;
+    private Boolean goGetImapUid;
+    private Long maxMembers;
+    @GraphQLInputField(name="attributes", description="If present, return only the specified attribute(s).")
+    private final List<AttributeName> attributes = Lists.newArrayList();
+    @GraphQLInputField(name="memberAttributes", description="If present, return only the specified attribute(s) for derefed members, applicable only when doDerefGroupMember is set.")
+    private final List<AttributeName> memberAttributes = Lists.newArrayList();
+    @GraphQLInputField(name="contacts", description="If present, only get the specified contact(s).")
+    private final List<Id> contacts = Lists.newArrayList();
+
+    public String getFolderId() {
+        return folderId;
+    }
+
+    @GraphQLInputField(name="folderId", description="If is present, return only contacts in the specified folder")
+    public void setFolderId(String folderId) {
+        this.folderId = folderId;
+    }
+
+    public String getSortBy() {
+        return sortBy;
+    }
+
+    @GraphQLInputField(name="sortBy", description="Sort By")
+    public void setSortBy(String sortBy) {
+        this.sortBy = sortBy;
+    }
+
+    public Boolean getDoSync() {
+        return doSync;
+    }
+
+    @GraphQLInputField(name="doSync", description="Denotes whether to return modified date (md) on contacts")
+    public void setDoSync(Boolean doSync) {
+        this.doSync = doSync;
+    }
+
+    public Boolean getDoDerefGroupMember() {
+        return doDerefGroupMember;
+    }
+
+    @GraphQLInputField(name="doDerefGroupMember", description="Denotes whether to deref contact group members")
+    public void setDoDerefGroupMember(Boolean doDerefGroupMember) {
+        this.doDerefGroupMember = doDerefGroupMember;
+    }
+
+    public Boolean getDoGetMemberOf() {
+        return doGetMemberOf;
+    }
+
+    @GraphQLInputField(name="doGetMemberOf", description="Denotes whether to include the list of contact groups this contact is a member of")
+    public void setDoGetMemberOf(Boolean doGetMemberOf) {
+        this.doGetMemberOf = doGetMemberOf;
+    }
+
+    public Boolean getDoGetHiddenAttrs() {
+        return doGetHiddenAttrs;
+    }
+
+    @GraphQLInputField(name="doGetHiddenAttrs", description="Denotes whether to return contact hidden attrs defined in zimbraContactHiddenAttributes")
+    public void setDoGetHiddenAttrs(Boolean doGetHiddenAttrs) {
+        this.doGetHiddenAttrs = doGetHiddenAttrs;
+    }
+
+    public Boolean getDoGetCertInfo() {
+        return doGetCertInfo;
+    }
+
+    @GraphQLInputField(name="doGetCertInfo", description="Denotes whether to return smime certificate info")
+    public void setDoGetCertInfo(Boolean doGetCertInfo) {
+        this.doGetCertInfo = doGetCertInfo;
+    }
+
+    public Boolean getDoGetImapUid() {
+        return goGetImapUid;
+    }
+
+    @GraphQLInputField(name="doGetImapUid", description="Set to return IMAP UID.  (default is unset.)")
+    public void setDoGetImapUid(Boolean doGetImapUid) {
+        this.goGetImapUid = doGetImapUid;
+    }
+
+    public Long getMaxMembers() {
+        return maxMembers;
+    }
+
+    @GraphQLInputField(name="maxMembers", description="Set to return IMAP UID.  (default is unset.)")
+    public void setMaxMembers(Long maxMembers) {
+        this.maxMembers = maxMembers;
+    }
+
+    public List<AttributeName> getAttributes() {
+        return attributes;
+    }
+
+    @GraphQLInputField(name="attributes", description="If present, return only the specified attribute(s).")
+    public void addAttributes(List<AttributeName> attrs) {
+        this.attributes.addAll(attrs);
+    }
+
+    public List<AttributeName> getMemberAttributes() {
+        return memberAttributes;
+    }
+
+    @GraphQLInputField(name="memberAttributes", description="If present, return only the specified attribute(s) for derefed members, applicable only when doDerefGroupMember is set.")
+    public void addMemberAttributes(List<AttributeName> attrs) {
+        this.memberAttributes.addAll(attrs);
+    }
+
+    public List<Id> getContacts() {
+        return contacts;
+    }
+
+    @GraphQLInputField(name="contacts", description="If present, only get the specified contact(s).")
+    public void addContacts(List<Id> contacts) {
+        this.contacts.addAll(contacts);
+    }
+
+}

--- a/src/java/com/zimbra/graphql/models/inputs/GQLGetContactsRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLGetContactsRequestInput.java
@@ -19,6 +19,7 @@ package com.zimbra.graphql.models.inputs;
 import java.util.List;
 
 import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.soap.type.AttributeName;
 import com.zimbra.soap.type.Id;
 
@@ -34,30 +35,30 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name="GetContactsRequest", description="Input for get contacts request.")
+@GraphQLType(name=GqlConstants.CLASS_GET_CONTACTS_REQUEST, description="Input for get contacts request.")
 public class GQLGetContactsRequestInput {
 
     private String folderId;
     private String sortBy;
     private Boolean doSync;
     private Boolean doDerefGroupMember;
-    private Boolean doGetMemberOf;
-    private Boolean doGetHiddenAttrs;
-    private Boolean doGetCertInfo;
-    private Boolean goGetImapUid;
+    private Boolean includeMemberOf;
+    private Boolean includeHiddenAttrs;
+    private Boolean includeCertInfo;
+    private Boolean includeImapUid;
     private Long maxMembers;
-    @GraphQLInputField(name="attributes", description="If present, return only the specified attribute(s).")
+    @GraphQLInputField(name=GqlConstants.ATTRIBUTES, description="If present, return only the specified attribute(s).")
     private final List<AttributeName> attributes = Lists.newArrayList();
-    @GraphQLInputField(name="memberAttributes", description="If present, return only the specified attribute(s) for derefed members, applicable only when doDerefGroupMember is set.")
+    @GraphQLInputField(name=GqlConstants.MEMBER_ATTRIBUTES, description="If present, return only the specified attribute(s) for derefed members, applicable only when doDerefGroupMember is set.")
     private final List<AttributeName> memberAttributes = Lists.newArrayList();
-    @GraphQLInputField(name="contacts", description="If present, only get the specified contact(s).")
+    @GraphQLInputField(name=GqlConstants.CONTACTS, description="If present, only get the specified contact(s).")
     private final List<Id> contacts = Lists.newArrayList();
 
     public String getFolderId() {
         return folderId;
     }
 
-    @GraphQLInputField(name="folderId", description="If is present, return only contacts in the specified folder")
+    @GraphQLInputField(name=GqlConstants.FOLDER_ID, description="If is present, return only contacts in the specified folder")
     public void setFolderId(String folderId) {
         this.folderId = folderId;
     }
@@ -66,7 +67,7 @@ public class GQLGetContactsRequestInput {
         return sortBy;
     }
 
-    @GraphQLInputField(name="sortBy", description="Sort By")
+    @GraphQLInputField(name=GqlConstants.SORT_BY, description="Sort By")
     public void setSortBy(String sortBy) {
         this.sortBy = sortBy;
     }
@@ -75,7 +76,7 @@ public class GQLGetContactsRequestInput {
         return doSync;
     }
 
-    @GraphQLInputField(name="doSync", description="Denotes whether to return modified date (md) on contacts")
+    @GraphQLInputField(name=GqlConstants.DO_SYNC, description="Denotes whether to return modified date (md) on contacts")
     public void setDoSync(Boolean doSync) {
         this.doSync = doSync;
     }
@@ -84,52 +85,52 @@ public class GQLGetContactsRequestInput {
         return doDerefGroupMember;
     }
 
-    @GraphQLInputField(name="doDerefGroupMember", description="Denotes whether to deref contact group members")
+    @GraphQLInputField(name=GqlConstants.DO_DEREF_GROUP_MEMBER, description="Denotes whether to deref contact group members")
     public void setDoDerefGroupMember(Boolean doDerefGroupMember) {
         this.doDerefGroupMember = doDerefGroupMember;
     }
 
-    public Boolean getDoGetMemberOf() {
-        return doGetMemberOf;
+    public Boolean getIncludeMemberOf() {
+        return includeMemberOf;
     }
 
-    @GraphQLInputField(name="doGetMemberOf", description="Denotes whether to include the list of contact groups this contact is a member of")
-    public void setDoGetMemberOf(Boolean doGetMemberOf) {
-        this.doGetMemberOf = doGetMemberOf;
+    @GraphQLInputField(name=GqlConstants.INCLUDE_MEMBER_OF, description="Denotes whether to include the list of contact groups this contact is a member of")
+    public void setIncludeMemberOf(Boolean includeMemberOf) {
+        this.includeMemberOf = includeMemberOf;
     }
 
-    public Boolean getDoGetHiddenAttrs() {
-        return doGetHiddenAttrs;
+    public Boolean getIncludeHiddenAttrs() {
+        return includeHiddenAttrs;
     }
 
-    @GraphQLInputField(name="doGetHiddenAttrs", description="Denotes whether to return contact hidden attrs defined in zimbraContactHiddenAttributes")
-    public void setDoGetHiddenAttrs(Boolean doGetHiddenAttrs) {
-        this.doGetHiddenAttrs = doGetHiddenAttrs;
+    @GraphQLInputField(name=GqlConstants.INCLUDE_HIDDEN_ATTRS, description="Denotes whether to return contact hidden attrs defined in zimbraContactHiddenAttributes")
+    public void setIncludeHiddenAttrs(Boolean includeHiddenAttrs) {
+        this.includeHiddenAttrs = includeHiddenAttrs;
     }
 
-    public Boolean getDoGetCertInfo() {
-        return doGetCertInfo;
+    public Boolean getIncludeCertInfo() {
+        return includeCertInfo;
     }
 
-    @GraphQLInputField(name="doGetCertInfo", description="Denotes whether to return smime certificate info")
-    public void setDoGetCertInfo(Boolean doGetCertInfo) {
-        this.doGetCertInfo = doGetCertInfo;
+    @GraphQLInputField(name=GqlConstants.INCLUDE_CERT_INFO, description="Denotes whether to return smime certificate info")
+    public void setIncludeCertInfo(Boolean includeCertInfo) {
+        this.includeCertInfo = includeCertInfo;
     }
 
-    public Boolean getDoGetImapUid() {
-        return goGetImapUid;
+    public Boolean getIncludeImapUid() {
+        return includeImapUid;
     }
 
-    @GraphQLInputField(name="doGetImapUid", description="Set to return IMAP UID.  (default is unset.)")
-    public void setDoGetImapUid(Boolean doGetImapUid) {
-        this.goGetImapUid = doGetImapUid;
+    @GraphQLInputField(name=GqlConstants.INCLUDE_IMAP_UID, description="Set to return IMAP UID.  (default is unset.)")
+    public void setIncludeImapUid(Boolean includeImapUid) {
+        this.includeImapUid = includeImapUid;
     }
 
     public Long getMaxMembers() {
         return maxMembers;
     }
 
-    @GraphQLInputField(name="maxMembers", description="Set to return IMAP UID.  (default is unset.)")
+    @GraphQLInputField(name=GqlConstants.MAX_MEMBERS, description="Set to return IMAP UID.  (default is unset.)")
     public void setMaxMembers(Long maxMembers) {
         this.maxMembers = maxMembers;
     }
@@ -138,7 +139,7 @@ public class GQLGetContactsRequestInput {
         return attributes;
     }
 
-    @GraphQLInputField(name="attributes", description="If present, return only the specified attribute(s).")
+    @GraphQLInputField(name=GqlConstants.ATTRIBUTES, description="If present, return only the specified attribute(s).")
     public void addAttributes(List<AttributeName> attrs) {
         this.attributes.addAll(attrs);
     }
@@ -147,7 +148,7 @@ public class GQLGetContactsRequestInput {
         return memberAttributes;
     }
 
-    @GraphQLInputField(name="memberAttributes", description="If present, return only the specified attribute(s) for derefed members, applicable only when doDerefGroupMember is set.")
+    @GraphQLInputField(name=GqlConstants.MEMBER_ATTRIBUTES, description="If present, return only the specified attribute(s) for derefed members, applicable only when doDerefGroupMember is set.")
     public void addMemberAttributes(List<AttributeName> attrs) {
         this.memberAttributes.addAll(attrs);
     }
@@ -156,7 +157,7 @@ public class GQLGetContactsRequestInput {
         return contacts;
     }
 
-    @GraphQLInputField(name="contacts", description="If present, only get the specified contact(s).")
+    @GraphQLInputField(name=GqlConstants.CONTACTS, description="If present, only get the specified contact(s).")
     public void addContacts(List<Id> contacts) {
         this.contacts.addAll(contacts);
     }

--- a/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
@@ -40,7 +40,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name=GqlConstants.SEARCH_REQUEST, description="Input for search request.")
+@GraphQLType(name=GqlConstants.CLASS_SEARCH_REQUEST, description="Input for search request.")
 public class GQLSearchRequestInput {
 
     protected Boolean includeTagDeleted;
@@ -58,10 +58,10 @@ public class GQLSearchRequestInput {
     protected String fetch;
     protected Boolean markRead;
     protected Integer maxInlinedLength;
-    protected Boolean wantHtml;
-    protected Boolean needCanExpand;
+    protected Boolean includeHtml;
+    protected Boolean includeIsExpandable;
     protected Boolean neuterImages;
-    protected WantRecipsSetting wantRecipients;
+    protected WantRecipsSetting includeRecipients;
     protected Boolean prefetch;
     protected String resultMode;
     protected Boolean fullConversation;
@@ -203,22 +203,22 @@ public class GQLSearchRequestInput {
         this.maxInlinedLength = maxInlinedLength;
     }
 
-    public Boolean getWantHtml() {
-        return wantHtml;
+    public Boolean getIncludeHtml() {
+        return includeHtml;
     }
 
-    @GraphQLInputField(name = GqlConstants.WANT_HTML, description="Inlined hits to return HTML parts if available")
-    public void setWantHtml(Boolean wantHtml) {
-        this.wantHtml = wantHtml;
+    @GraphQLInputField(name = GqlConstants.INCLUDE_HTML, description="Inlined hits to return HTML parts if available")
+    public void setIncludeHtml(Boolean includeHtml) {
+        this.includeHtml = includeHtml;
     }
 
-    public Boolean getNeedCanExpand() {
-        return needCanExpand;
+    public Boolean getIncludeIsExpandable() {
+        return includeIsExpandable;
     }
 
-    @GraphQLInputField(name = GqlConstants.NEED_CAN_EXPAND, description="If `needExp` is set in the request, two additional flags may be included in `emails` results elements for messages returned inline. (1) `isGroup`: set if the email address is a group. (2) `exp`: present only when `isGroup` set to true. Unset if the authenticated user does not have permission to expand group members")
-    public void setNeedCanExpand(Boolean needCanExpand) {
-        this.needCanExpand = needCanExpand;
+    @GraphQLInputField(name = GqlConstants.INCLUDE_IS_EXPANDABLE, description="Denotes whether two additional flags may be included in `emails` results elements for messages returned inline. (1) `isGroup`: set if the email address is a group. (2) `exp`: present only when `isGroup` set to true. Unset if the authenticated user does not have permission to expand group members")
+    public void setIncludeIsExpandable(Boolean includeIsExpandable) {
+        this.includeIsExpandable = includeIsExpandable;
     }
 
     public Boolean getNeuterImages() {
@@ -230,13 +230,13 @@ public class GQLSearchRequestInput {
         this.neuterImages = neuterImages;
     }
 
-    public WantRecipsSetting getWantRecipients() {
-        return wantRecipients;
+    public WantRecipsSetting getIncludeRecipients() {
+        return includeRecipients;
     }
 
-    @GraphQLInputField(name = GqlConstants.WANT_RECEPIENTS, description="Want recipients setting. If true, sent messages that contain the \"To:\" recipients instead of the sender. Returned conversations whose first hit was sent by the user will contain that hit's \"To:\" recipients instead of the conversation's sender list")
-    public void setWantRecipients(WantRecipsSetting wantRecipients) {
-        this.wantRecipients = wantRecipients;
+    @GraphQLInputField(name = GqlConstants.INCLUDE_RECEPIENTS, description="If true, sent messages that contain the \"To:\" recipients instead of the sender. Returned conversations whose first hit was sent by the user will contain that hit's \"To:\" recipients instead of the conversation's sender list")
+    public void setIncludeRecipients(WantRecipsSetting includeRecipients) {
+        this.includeRecipients = includeRecipients;
     }
 
     public Boolean getPrefetch() {

--- a/src/java/com/zimbra/graphql/models/outputs/AccountInfo.java
+++ b/src/java/com/zimbra/graphql/models/outputs/AccountInfo.java
@@ -27,13 +27,13 @@ import io.leangen.graphql.annotations.GraphQLNonNull;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
-@GraphQLType(name=GqlConstants.ACCOUNT_INFO, description="account info response data")
+@GraphQLType(name=GqlConstants.CLASS_ACCOUNT_INFO, description="account info response data")
 public class AccountInfo {
     @GraphQLNonNull
     @GraphQLQuery(name=GqlConstants.NAME)
     private String name;
     @GraphQLNonNull
-    @GraphQLQuery(name=GqlConstants.ATTRS, description="account attributes")
+    @GraphQLQuery(name=GqlConstants.ATTRIBUTES, description="account attributes")
     private List<NamedValue> attrs = Lists.newArrayList();
     @GraphQLQuery(name=GqlConstants.SOAP_URL, description="soap url")
     private String soapURL;

--- a/src/java/com/zimbra/graphql/models/outputs/GQLConversationSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLConversationSearchResponse.java
@@ -36,7 +36,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name = GqlConstants.CONVERSATION_SEARCH_RESPONSE, description = "Search response data for a conversation search")
+@GraphQLType(name = GqlConstants.CLASS_CONVERSATION_SEARCH_RESPONSE, description = "Search response data for a conversation search")
 public class GQLConversationSearchResponse extends GQLSearchResponse {
 
     @Override

--- a/src/java/com/zimbra/graphql/models/outputs/GQLMessageSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLMessageSearchResponse.java
@@ -36,7 +36,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name = GqlConstants.MESSAGE_SEARCH_RESPONSE, description = "Search response data for a message search")
+@GraphQLType(name = GqlConstants.CLASS_MESSAGE_SEARCH_RESPONSE, description = "Search response data for a message search")
 public class GQLMessageSearchResponse extends GQLSearchResponse {
 
     @Override

--- a/src/java/com/zimbra/graphql/models/outputs/GQLSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSearchResponse.java
@@ -38,7 +38,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name = GqlConstants.SEARCH_RESPONSE, description = "Search response data")
+@GraphQLType(name = GqlConstants.CLASS_SEARCH_RESPONSE, description = "Search response data")
 public class GQLSearchResponse {
 
 	protected String sortBy;

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
@@ -1,0 +1,181 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
+import com.zimbra.cs.service.mail.ContactAction;
+import com.zimbra.cs.service.mail.CreateContact;
+import com.zimbra.cs.service.mail.GetContacts;
+import com.zimbra.cs.service.mail.ItemAction;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.inputs.GQLGetContactsRequestInput;
+import com.zimbra.graphql.repositories.IRepository;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.ContactActionRequest;
+import com.zimbra.soap.mail.message.CreateContactRequest;
+import com.zimbra.soap.mail.message.GetContactsRequest;
+import com.zimbra.soap.mail.message.GetContactsResponse;
+import com.zimbra.soap.mail.type.ContactActionSelector;
+import com.zimbra.soap.mail.type.ContactInfo;
+import com.zimbra.soap.mail.type.ContactSpec;
+import com.zimbra.soap.mail.type.FolderActionResult;
+
+/**
+ * The ZXMLContactRepository class.<br>
+ * Contains XML document based data access methods for contacts.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.repositories.impl
+ * @copyright Copyright © 2018
+ */
+public class ZXMLContactRepository extends ZXMLItemRepository implements IRepository {
+
+    /**
+     * The createContact document handler.
+     */
+    protected final CreateContact createContactHandler;
+
+    /**
+     * The getContact document handler.
+     */
+    protected final GetContacts getContactHandler;
+
+    /**
+     * Creates an instance with default document handlers.
+     */
+    public ZXMLContactRepository() {
+        this(new ContactAction(), new CreateContact(), new GetContacts());
+    }
+
+    /**
+     * Creates an instance with specified handlers.
+     *
+     * @param actionHandler The item action handler
+     * @param createHandler The create contact handler
+     * @param getHandler The get contacts handler
+     */
+    public ZXMLContactRepository(ItemAction actionHandler, CreateContact createHandler,
+        GetContacts getHandler) {
+        super(actionHandler);
+        this.createContactHandler = createHandler;
+        this.getContactHandler = getHandler;
+    }
+
+    /**
+     * Retrieves a contact by given properties.
+     *
+     * @param rctxt The request context
+     * @param input The contact fetch input
+     * @return Fetch contact results
+     * @throws ServiceException If there are issues executing the document
+     */
+    public List<ContactInfo> contacts(RequestContext rctxt, GQLGetContactsRequestInput input)
+        throws ServiceException {
+        // get auth context
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        // map the request params
+        final GetContactsRequest req = new GetContactsRequest();
+        if (input != null) {
+            req.setFolderId(input.getFolderId());
+            req.setSortBy(input.getSortBy());
+            req.setSync(input.getDoSync());
+            req.setDerefGroupMember(input.getDoDerefGroupMember());
+            req.setIncludeMemberOf(input.getDoGetMemberOf());
+            req.setReturnHiddenAttrs(input.getDoGetHiddenAttrs());
+            req.setReturnCertInfo(input.getDoGetCertInfo());
+            req.setWantImapUid(input.getDoGetImapUid());
+            req.setMaxMembers(input.getMaxMembers());
+            req.setAttributes(input.getAttributes());
+            req.setMemberAttributes(input.getMemberAttributes());
+            req.setContacts(input.getContacts());
+        }
+        // execute
+        final Element response = XMLDocumentUtilities.executeDocument(
+            getContactHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(req));
+        if (response != null) {
+            final GetContactsResponse contactsResponse = XMLDocumentUtilities.fromElement(
+                response,
+                GetContactsResponse.class);
+            if (contactsResponse != null) {
+                return contactsResponse.getContacts();
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Create a contact with given properties.
+     *
+     * @param rctxt The request context
+     * @param doGetImapUid Denotes whether to return IMAP UID
+     * @param doVerbose If set, the returned <cn> is just a placeholder containing the new contact ID
+     * @param doGetModifiedSequence Denotes whether to return the modified sequence
+     * @param contactToCreate The contact to create
+     * @return The newly created contact
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ContactInfo contactCreate(RequestContext rctxt, Boolean doGetImapUid, Boolean doVerbose,
+        Boolean doGetModifiedSequence, ContactSpec contactToCreate) throws ServiceException {
+        // get auth context
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        // execute
+        final CreateContactRequest req = new CreateContactRequest(contactToCreate);
+        req.setVerbose(doVerbose);
+        req.setWantImapUid(doGetImapUid);
+        req.setWantModifiedSequence(doGetModifiedSequence);
+        final Element response = XMLDocumentUtilities.executeDocument(
+            createContactHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(req));
+        ContactInfo zCreatedContact = null;
+        if (response != null) {
+            zCreatedContact = XMLDocumentUtilities
+                .fromElement(response.getElement(MailConstants.E_CONTACT), ContactInfo.class);
+        }
+        return zCreatedContact;
+    }
+
+    /**
+     * Performs a contact action with given properties.
+     *
+     * @param rctxt The request context
+     * @param input The properties
+     * @return Action result (contact action DOES return a FolderActionResult)
+     * @throws ServiceException If there are issues executing the document
+     */
+    public FolderActionResult contactAction(RequestContext rctxt, ContactActionSelector input)
+        throws ServiceException {
+        final ContactActionRequest req = new ContactActionRequest(input);
+        final Element response = super.action(rctxt, req);
+        FolderActionResult result = null;
+        if (response != null) {
+            result = XMLDocumentUtilities.fromElement(response.getElement(MailConstants.E_ACTION),
+                FolderActionResult.class);
+        }
+        return result;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
@@ -102,10 +102,10 @@ public class ZXMLContactRepository extends ZXMLItemRepository implements IReposi
             req.setSortBy(input.getSortBy());
             req.setSync(input.getDoSync());
             req.setDerefGroupMember(input.getDoDerefGroupMember());
-            req.setIncludeMemberOf(input.getDoGetMemberOf());
-            req.setReturnHiddenAttrs(input.getDoGetHiddenAttrs());
-            req.setReturnCertInfo(input.getDoGetCertInfo());
-            req.setWantImapUid(input.getDoGetImapUid());
+            req.setIncludeMemberOf(input.getIncludeMemberOf());
+            req.setReturnHiddenAttrs(input.getIncludeHiddenAttrs());
+            req.setReturnCertInfo(input.getIncludeCertInfo());
+            req.setWantImapUid(input.getIncludeImapUid());
             req.setMaxMembers(input.getMaxMembers());
             req.setAttributes(input.getAttributes());
             req.setMemberAttributes(input.getMemberAttributes());
@@ -131,22 +131,22 @@ public class ZXMLContactRepository extends ZXMLItemRepository implements IReposi
      * Create a contact with given properties.
      *
      * @param rctxt The request context
-     * @param doGetImapUid Denotes whether to return IMAP UID
-     * @param doVerbose If set, the returned <cn> is just a placeholder containing the new contact ID
-     * @param doGetModifiedSequence Denotes whether to return the modified sequence
+     * @param includeImapUid Denotes whether to return IMAP UID
+     * @param doVerbose If set, the returned info is just a placeholder containing the new contact ID
+     * @param includeModifiedSequence Denotes whether to return the modified sequence
      * @param contactToCreate The contact to create
      * @return The newly created contact
      * @throws ServiceException If there are issues executing the document
      */
-    public ContactInfo contactCreate(RequestContext rctxt, Boolean doGetImapUid, Boolean doVerbose,
-        Boolean doGetModifiedSequence, ContactSpec contactToCreate) throws ServiceException {
+    public ContactInfo contactCreate(RequestContext rctxt, Boolean includeImapUid, Boolean doVerbose,
+        Boolean includeModifiedSequence, ContactSpec contactToCreate) throws ServiceException {
         // get auth context
         final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
         // execute
         final CreateContactRequest req = new CreateContactRequest(contactToCreate);
         req.setVerbose(doVerbose);
-        req.setWantImapUid(doGetImapUid);
-        req.setWantModifiedSequence(doGetModifiedSequence);
+        req.setWantImapUid(includeImapUid);
+        req.setWantModifiedSequence(includeModifiedSequence);
         final Element response = XMLDocumentUtilities.executeDocument(
             createContactHandler,
             zsc,

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
@@ -40,6 +40,7 @@ import com.zimbra.soap.mail.type.ContactActionSelector;
 import com.zimbra.soap.mail.type.ContactInfo;
 import com.zimbra.soap.mail.type.ContactSpec;
 import com.zimbra.soap.mail.type.FolderActionResult;
+import com.zimbra.soap.mail.type.NewContactAttr;
 
 /**
  * The ZXMLContactRepository class.<br>
@@ -176,6 +177,33 @@ public class ZXMLContactRepository extends ZXMLItemRepository implements IReposi
                 FolderActionResult.class);
         }
         return result;
+    }
+
+    /**
+     * Performs an update action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param folderId A folderId to set
+     * @param flags The flags to set
+     * @param tagNames The tags to set
+     * @param rgb The rgb to set
+     * @param color The color to set
+     * @param attributes The attributes to set
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public FolderActionResult contactUpdate(RequestContext rctxt, String ids, String folderId,
+        String flags, String tagNames, String rgb, Byte color, List<NewContactAttr> attributes)
+        throws ServiceException {
+        final ContactActionSelector input = new ContactActionSelector(ids, MailConstants.OP_UPDATE);
+        input.setFolder(folderId);
+        input.setFlags(flags);
+        input.setTagNames(tagNames);
+        input.setRgb(rgb);
+        input.setColor(color);
+        input.setAttrs(attributes);
+        return contactAction(rctxt, input);
     }
 
 }

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
@@ -158,7 +158,6 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
      * Create a folder with given properties.
      *
      * @param rctxt The request context
-     * @param account The account to create the folder
      * @param folderToCreate New folder properties
      * @return The newly created folder
      * @throws ServiceException If there are issues executing the document

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLItemRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLItemRepository.java
@@ -18,11 +18,16 @@ package com.zimbra.graphql.repositories.impl;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.MailConstants;
 import com.zimbra.cs.service.mail.ItemAction;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.repositories.IRepository;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
 import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.ItemActionRequest;
+import com.zimbra.soap.mail.type.ActionResult;
+import com.zimbra.soap.mail.type.ActionSelector;
 
 /**
  * The ZXMLItemRepository class.<br>
@@ -53,8 +58,8 @@ public class ZXMLItemRepository extends ZXMLRepository implements IRepository {
      * Performs an item action with given properties.
      *
      * @param rctxt The request context
-     * @param input The properties
-     * @return Action result
+     * @param req The request element
+     * @return An XML response object
      * @throws ServiceException If there are issues executing the document
      */
     public Element action(RequestContext rctxt, Object req) throws ServiceException {
@@ -63,6 +68,173 @@ public class ZXMLItemRepository extends ZXMLRepository implements IRepository {
             GQLAuthUtilities.getZimbraSoapContext(rctxt),
             XMLDocumentUtilities.toElement(req));
         return response;
+    }
+
+    /**
+     * Performs an item action with given properties.
+     *
+     * @param rctxt The request context
+     * @param input The input properties to wrap in an item action request
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemAction(RequestContext rctxt, ActionSelector input) throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final ItemActionRequest req = new ItemActionRequest(input);
+        // execute
+        final Element response = XMLDocumentUtilities.executeDocument(
+            actionHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(req));
+        // return operation results
+        ActionResult result = null;
+        if (response != null) {
+            result = XMLDocumentUtilities.fromElement(response.getElement(MailConstants.E_ACTION),
+                ActionResult.class);
+        }
+        return result;
+    }
+
+    /**
+     * Performs a move action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param folderId The destination folder
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemMove(RequestContext rctxt, String ids, String folderId,
+        String constraint) throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, MailConstants.OP_MOVE);
+        input.setFolder(folderId);
+        input.setConstraint(constraint);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs a copy action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param folderId The destination folder
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemCopy(RequestContext rctxt, String ids, String folderId,
+        String constraint) throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, MailConstants.OP_COPY);
+        input.setFolder(folderId);
+        input.setConstraint(constraint);
+        input.setNewlyCreatedIds(true);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs a delete action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemDelete(RequestContext rctxt, String ids, String constraint)
+        throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, MailConstants.OP_HARD_DELETE);
+        input.setConstraint(constraint);
+        input.setNonExistentIds(true);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs a trash action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemTrash(RequestContext rctxt, String ids, String constraint)
+        throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, MailConstants.OP_TRASH);
+        input.setConstraint(constraint);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs a flag action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param flags The flags to add
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemFlag(RequestContext rctxt, String ids, String flags,
+        String constraint) throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, MailConstants.OP_FLAG);
+        input.setFlags(flags);
+        input.setConstraint(constraint);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs an unflag action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param flags The flags to remove
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemUnflag(RequestContext rctxt, String ids, String flags,
+        String constraint) throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, "!" + MailConstants.OP_FLAG);
+        input.setFlags(flags);
+        input.setConstraint(constraint);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs a tag action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param tagNames The tags to add
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemTag(RequestContext rctxt, String ids, String tagNames,
+        String constraint) throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, MailConstants.OP_TAG);
+        input.setTagNames(tagNames);
+        input.setConstraint(constraint);
+        return itemAction(rctxt, input);
+    }
+
+    /**
+     * Performs an untag action with given properties.
+     *
+     * @param rctxt The request context
+     * @param ids Comma-separated item ids to act on
+     * @param tagNames The tags to remove
+     * @param constraints Target constraints
+     * @return Action result
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ActionResult itemUntag(RequestContext rctxt, String ids, String tagNames,
+        String constraint) throws ServiceException {
+        final ActionSelector input = new ActionSelector(ids, "!" + MailConstants.OP_TAG);
+        input.setTagNames(tagNames);
+        input.setConstraint(constraint);
+        return itemAction(rctxt, input);
     }
 
 }

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLSearchRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLSearchRepository.java
@@ -132,10 +132,10 @@ public class ZXMLSearchRepository extends ZXMLRepository implements IRepository 
         req.setFetch(searchInput.getFetch());
         req.setMarkRead(searchInput.getMarkRead());
         req.setMaxInlinedLength(searchInput.getMaxInlinedLength());
-        req.setWantHtml(searchInput.getWantHtml());
-        req.setNeedCanExpand(searchInput.getNeedCanExpand());
+        req.setWantHtml(searchInput.getIncludeHtml());
+        req.setNeedCanExpand(searchInput.getIncludeIsExpandable());
         req.setNeuterImages(searchInput.getNeuterImages());
-        req.setWantRecipients(searchInput.getWantRecipients());
+        req.setWantRecipients(searchInput.getIncludeRecipients());
         req.setPrefetch(searchInput.getPrefetch());
         req.setResultMode(searchInput.getResultMode());
         req.setFullConversation(searchInput.getFullConversation());

--- a/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
@@ -27,6 +27,7 @@ import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.mail.type.ContactInfo;
 import com.zimbra.soap.mail.type.ContactSpec;
 import com.zimbra.soap.mail.type.FolderActionResult;
+import com.zimbra.soap.mail.type.ModifyContactSpec;
 import com.zimbra.soap.mail.type.NewContactAttr;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
@@ -153,5 +154,16 @@ public class ContactResolver {
         @GraphQLArgument(name=GqlConstants.ATTRIBUTES, description="The attributes to set") List<NewContactAttr> attributes,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.contactUpdate(context, ids, folderId, flags, tagNames, rgb, color, attributes);
+    }
+
+    @GraphQLMutation(description="Modifies a given contact with the specified properties.")
+    public ContactInfo contactModify(
+        @GraphQLArgument(name=GqlConstants.DO_REPLACE, description="Denotes whether to replace or append attributes and group members") Boolean doReplace,
+        @GraphQLArgument(name=GqlConstants.DO_VERBOSE, description="If set, the returned info is just a placeholder containing the new contact ID") Boolean doVerbose,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_IMAP_UID, description="Denotes whether to return IMAP UID") Boolean includeImapUid,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_MODIFIED_SEQUENCE, description="Denotes whether to return the modified sequence") Boolean includeModifiedSequence,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.CONTACT, description="The contact properties to modify") ModifyContactSpec contact,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.contactModify(context, doReplace, doVerbose, includeImapUid, includeModifiedSequence, contact);
     }
 }

--- a/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
@@ -18,6 +18,7 @@ package com.zimbra.graphql.resolvers.impl;
 
 import java.util.List;
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLGetContactsRequestInput;
@@ -56,100 +57,100 @@ public class ContactResolver {
     }
 
     @GraphQLQuery(description="Retrieve contacts by given properties.")
-    public List<ContactInfo> contacts(@GraphQLArgument(name="input") GQLGetContactsRequestInput input,
+    public List<ContactInfo> contacts(@GraphQLArgument(name=GqlConstants.INPUT) GQLGetContactsRequestInput input,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.contacts(context, input);
     }
 
     @GraphQLMutation(description="Create a contact with given properties.")
     public ContactInfo contactCreate(
-        @GraphQLArgument(name="doGetImapUid", description="Denotes whether to return IMAP UID") Boolean doGetImapUid,
-        @GraphQLArgument(name="doVerbose", description="If set, the returned <cn> is just a placeholder containing the new contact ID") Boolean doVerbose,
-        @GraphQLArgument(name="doGetModifiedSequence", description="Denotes whether to return the modified sequence") Boolean doGetModifiedSequence,
-        @GraphQLNonNull @GraphQLArgument(name="contact", description="The contact to create") ContactSpec contact,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_IMAP_UID, description="Denotes whether to return IMAP UID") Boolean includeImapUid,
+        @GraphQLArgument(name=GqlConstants.DO_VERBOSE, description="If set, the returned info is just a placeholder containing the new contact ID") Boolean doVerbose,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_MODIFIED_SEQUENCE, description="Denotes whether to return the modified sequence") Boolean includeModifiedSequence,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.CONTACT, description="The contact to create") ContactSpec contact,
         @GraphQLRootContext RequestContext context) throws ServiceException {
-        return contactRepository.contactCreate(context, doGetImapUid, doVerbose, doGetModifiedSequence, contact);
+        return contactRepository.contactCreate(context, includeImapUid, doVerbose, includeModifiedSequence, contact);
     }
 
     @GraphQLMutation(description="Moves the given contacts to the specified folder.")
     public ActionResult contactMove(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLNonNull @GraphQLArgument(name="folderId", description="The destination folder") String folderId,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.FOLDER_ID, description="The destination folder") String folderId,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemMove(context, ids, folderId, constraint);
     }
 
     @GraphQLMutation(description="Copies the given contacts to the specified folder.")
     public ActionResult contactCopy(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLNonNull @GraphQLArgument(name="folderId", description="The destination folder") String folderId,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.FOLDER_ID, description="The destination folder") String folderId,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemCopy(context, ids, folderId, constraint);
     }
 
     @GraphQLMutation(description="Deletes the given contacts.")
     public ActionResult contactDelete(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemDelete(context, ids, constraint);
     }
 
     @GraphQLMutation(description="Adds the specified flags on the given contacts.")
     public ActionResult contactFlag(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLNonNull @GraphQLArgument(name="flags", description="The flags to add") String flags,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.FLAGS, description="The flags to add") String flags,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemFlag(context, ids, flags, constraint);
     }
 
     @GraphQLMutation(description="Removes the specified flags from the given contacts.")
-    public ActionResult contactUnFlag(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLNonNull @GraphQLArgument(name="flags", description="The flags to remove") String flags,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+    public ActionResult contactUnflag(
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.FLAGS, description="The flags to remove") String flags,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemUnflag(context, ids, flags, constraint);
     }
 
     @GraphQLMutation(description="Trashes the given contacts.")
     public ActionResult contactTrash(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemTrash(context, ids, constraint);
     }
 
     @GraphQLMutation(description="Adds the specified tags to the given contacts.")
     public ActionResult contactTag(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLNonNull @GraphQLArgument(name="tagNames", description="The tags to add") String tagNames,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.TAG_NAMES, description="The tags to add") String tagNames,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemTag(context, ids, tagNames, constraint);
     }
 
     @GraphQLMutation(description="Removes the specified tags from the given contacts.")
     public ActionResult contactUntag(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLNonNull @GraphQLArgument(name="tagNames", description="The tags to remove") String tagNames,
-        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.TAG_NAMES, description="The tags to remove") String tagNames,
+        @GraphQLArgument(name=GqlConstants.CONSTRAINT, description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.itemUntag(context, ids, tagNames, constraint);
     }
 
     @GraphQLMutation(description="Updates a given contact with the specified properties.")
     public FolderActionResult contactUpdate(
-        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
-        @GraphQLArgument(name="folderId", description="The destination folder") String folderId,
-        @GraphQLArgument(name="flags", description="The flags to set") String flags,
-        @GraphQLArgument(name="tagNames", description="The tags to set") String tagNames,
-        @GraphQLArgument(name="rgb", description="RGB color in format #rrggbb where r,g and b are hex digits") String rgb,
-        @GraphQLArgument(name="color", description="color numeric; range 0-127; defaults to 0 if not present; client can display only 0-7") Byte color,
-        @GraphQLArgument(name="attributes", description="The attributes to set") List<NewContactAttr> attributes,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDS, description="Comma-separated item ids to act on") String ids,
+        @GraphQLArgument(name=GqlConstants.FOLDER_ID, description="The destination folder") String folderId,
+        @GraphQLArgument(name=GqlConstants.FLAGS, description="The flags to set") String flags,
+        @GraphQLArgument(name=GqlConstants.TAG_NAMES, description="The tags to set") String tagNames,
+        @GraphQLArgument(name=GqlConstants.RGB, description="RGB color in format #rrggbb where r,g and b are hex digits") String rgb,
+        @GraphQLArgument(name=GqlConstants.COLOR, description="color numeric; range 0-127; defaults to 0 if not present; client can display only 0-7") Byte color,
+        @GraphQLArgument(name=GqlConstants.ATTRIBUTES, description="The attributes to set") List<NewContactAttr> attributes,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.contactUpdate(context, ids, folderId, flags, tagNames, rgb, color, attributes);
     }

--- a/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
@@ -22,10 +22,11 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLGetContactsRequestInput;
 import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
-import com.zimbra.soap.mail.type.ContactActionSelector;
+import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.mail.type.ContactInfo;
 import com.zimbra.soap.mail.type.ContactSpec;
 import com.zimbra.soap.mail.type.FolderActionResult;
+import com.zimbra.soap.mail.type.NewContactAttr;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLMutation;
@@ -54,26 +55,102 @@ public class ContactResolver {
         this.contactRepository = contactRepository;
     }
 
-    @GraphQLQuery(description = "Retrieve contacts by given properties.")
+    @GraphQLQuery(description="Retrieve contacts by given properties.")
     public List<ContactInfo> contacts(@GraphQLArgument(name="input") GQLGetContactsRequestInput input,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.contacts(context, input);
     }
 
-    @GraphQLMutation(description = "Create a contact with given properties.")
+    @GraphQLMutation(description="Create a contact with given properties.")
     public ContactInfo contactCreate(
         @GraphQLArgument(name="doGetImapUid", description="Denotes whether to return IMAP UID") Boolean doGetImapUid,
         @GraphQLArgument(name="doVerbose", description="If set, the returned <cn> is just a placeholder containing the new contact ID") Boolean doVerbose,
         @GraphQLArgument(name="doGetModifiedSequence", description="Denotes whether to return the modified sequence") Boolean doGetModifiedSequence,
-        @GraphQLArgument(name="contact", description="The contact to create") ContactSpec contact,
+        @GraphQLNonNull @GraphQLArgument(name="contact", description="The contact to create") ContactSpec contact,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return contactRepository.contactCreate(context, doGetImapUid, doVerbose, doGetModifiedSequence, contact);
     }
 
-    @GraphQLMutation(description = "Handles a contact action request.")
-    public FolderActionResult contactAction(
-        @GraphQLNonNull @GraphQLArgument(name="input") ContactActionSelector input,
+    @GraphQLMutation(description="Moves the given contacts to the specified folder.")
+    public ActionResult contactMove(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name="folderId", description="The destination folder") String folderId,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
         @GraphQLRootContext RequestContext context) throws ServiceException {
-        return contactRepository.contactAction(context, input);
+        return contactRepository.itemMove(context, ids, folderId, constraint);
+    }
+
+    @GraphQLMutation(description="Copies the given contacts to the specified folder.")
+    public ActionResult contactCopy(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name="folderId", description="The destination folder") String folderId,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemCopy(context, ids, folderId, constraint);
+    }
+
+    @GraphQLMutation(description="Deletes the given contacts.")
+    public ActionResult contactDelete(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemDelete(context, ids, constraint);
+    }
+
+    @GraphQLMutation(description="Adds the specified flags on the given contacts.")
+    public ActionResult contactFlag(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name="flags", description="The flags to add") String flags,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemFlag(context, ids, flags, constraint);
+    }
+
+    @GraphQLMutation(description="Removes the specified flags from the given contacts.")
+    public ActionResult contactUnFlag(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name="flags", description="The flags to remove") String flags,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemUnflag(context, ids, flags, constraint);
+    }
+
+    @GraphQLMutation(description="Trashes the given contacts.")
+    public ActionResult contactTrash(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemTrash(context, ids, constraint);
+    }
+
+    @GraphQLMutation(description="Adds the specified tags to the given contacts.")
+    public ActionResult contactTag(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name="tagNames", description="The tags to add") String tagNames,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemTag(context, ids, tagNames, constraint);
+    }
+
+    @GraphQLMutation(description="Removes the specified tags from the given contacts.")
+    public ActionResult contactUntag(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLNonNull @GraphQLArgument(name="tagNames", description="The tags to remove") String tagNames,
+        @GraphQLArgument(name="constraint", description="Target constraints") String constraint,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.itemUntag(context, ids, tagNames, constraint);
+    }
+
+    @GraphQLMutation(description="Updates a given contact with the specified properties.")
+    public FolderActionResult contactUpdate(
+        @GraphQLNonNull @GraphQLArgument(name="ids", description="Comma-separated item ids to act on") String ids,
+        @GraphQLArgument(name="folderId", description="The destination folder") String folderId,
+        @GraphQLArgument(name="flags", description="The flags to set") String flags,
+        @GraphQLArgument(name="tagNames", description="The tags to set") String tagNames,
+        @GraphQLArgument(name="rgb", description="RGB color in format #rrggbb where r,g and b are hex digits") String rgb,
+        @GraphQLArgument(name="color", description="color numeric; range 0-127; defaults to 0 if not present; client can display only 0-7") Byte color,
+        @GraphQLArgument(name="attributes", description="The attributes to set") List<NewContactAttr> attributes,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.contactUpdate(context, ids, folderId, flags, tagNames, rgb, color, attributes);
     }
 }

--- a/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
@@ -1,0 +1,79 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resolvers.impl;
+
+import java.util.List;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.inputs.GQLGetContactsRequestInput;
+import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
+import com.zimbra.soap.mail.type.ContactActionSelector;
+import com.zimbra.soap.mail.type.ContactInfo;
+import com.zimbra.soap.mail.type.ContactSpec;
+import com.zimbra.soap.mail.type.FolderActionResult;
+
+import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+
+/**
+ * The ContactResolver class.<br>
+ * Contains contact schema resources.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.resolvers.impl
+ * @copyright Copyright © 2018
+ */
+public class ContactResolver {
+
+    protected ZXMLContactRepository contactRepository = null;
+
+    /**
+     * Creates an instance with specified contact repository.
+     *
+     * @param contactRepository The contact repository
+     */
+    public ContactResolver(ZXMLContactRepository contactRepository) {
+        this.contactRepository = contactRepository;
+    }
+
+    @GraphQLQuery(description = "Retrieve contacts by given properties.")
+    public List<ContactInfo> contacts(@GraphQLArgument(name="input") GQLGetContactsRequestInput input,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.contacts(context, input);
+    }
+
+    @GraphQLMutation(description = "Create a contact with given properties.")
+    public ContactInfo contactCreate(
+        @GraphQLArgument(name="doGetImapUid", description="Denotes whether to return IMAP UID") Boolean doGetImapUid,
+        @GraphQLArgument(name="doVerbose", description="If set, the returned <cn> is just a placeholder containing the new contact ID") Boolean doVerbose,
+        @GraphQLArgument(name="doGetModifiedSequence", description="Denotes whether to return the modified sequence") Boolean doGetModifiedSequence,
+        @GraphQLArgument(name="contact", description="The contact to create") ContactSpec contact,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.contactCreate(context, doGetImapUid, doVerbose, doGetModifiedSequence, contact);
+    }
+
+    @GraphQLMutation(description = "Handles a contact action request.")
+    public FolderActionResult contactAction(
+        @GraphQLNonNull @GraphQLArgument(name="input") ContactActionSelector input,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return contactRepository.contactAction(context, input);
+    }
+}

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -37,10 +37,12 @@ import com.zimbra.cs.extension.ExtensionHttpHandler;
 import com.zimbra.graphql.errors.GQLError;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
 import com.zimbra.graphql.resolvers.impl.AccountResolver;
 import com.zimbra.graphql.resolvers.impl.AuthResolver;
+import com.zimbra.graphql.resolvers.impl.ContactResolver;
 import com.zimbra.graphql.resolvers.impl.FolderResolver;
 import com.zimbra.graphql.resolvers.impl.SearchResolver;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
@@ -225,6 +227,7 @@ public class GQLServlet extends ExtensionHttpHandler {
     protected GraphQLSchema buildSchema() {
         final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
         final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository());
+        final ContactResolver contactResolver = new ContactResolver(new ZXMLContactRepository());
         final FolderResolver folderResolver = new FolderResolver(new ZXMLFolderRepository());
         final SearchResolver searchResolver = new SearchResolver(new ZXMLSearchRepository());
         ZimbraLog.extensions.info("Generating schema with loaded resolvers . . .");
@@ -235,6 +238,7 @@ public class GQLServlet extends ExtensionHttpHandler {
             .withOperationsFromSingletons(
                 accountResolver,
                 authResolver,
+                contactResolver,
                 folderResolver,
                 searchResolver
             ).generate();


### PR DESCRIPTION
* Support for contacts resolver and repository.
  * Fetch contact(s)
  * Create contacts
  * Actions (including item actions - e.g. update, delete) - separated, as per discussion with @swapnilpingle89. See jira ticket for details.
    * Shared actions added in Item repo for re-use by other repos as needed. The remaining shared actions should be added there.
* Updated some booleans for consistency (using `include`, `is`, `do` since they're most common).
  * This affects some gql search resource properties:
    * `wantHtml` -> `includeHtml`
    * `needCanExpand` -> `includeIsExpandable` (the resulting property as `isExpandable`)
    * `wantRecipients` -> `includeRecipients`

**Testing Done**
Minimal testing with basic properties for all resources, see jira ticket for some example queries/mutations.

**Testing to be done by QA**
See testrail.

See associated PR Zimbra/zm-mailbox#720 for more info.
