### PR TITLE
ZCS-4167: Requested fixes, searchType now not visible in query input …

### DIFF
--- a/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
@@ -18,6 +18,7 @@ package com.zimbra.graphql.models.inputs;
 
 import java.util.List;
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.soap.mail.type.CalTZInfo;
 import com.zimbra.soap.type.AttributeName;
 import com.zimbra.soap.type.CursorInfo;
@@ -39,7 +40,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name="SearchRequest", description="Input for search request.")
+@GraphQLType(name=GqlConstants.SEARCH_REQUEST, description="Input for search request.")
 public class GQLSearchRequestInput {
 
     protected Boolean includeTagDeleted;
@@ -74,588 +75,275 @@ public class GQLSearchRequestInput {
     protected Boolean includeMemberOf;
     protected List<AttributeName> headers;
 
-    /**
-     * Gets the value of includeTagDeleted.
-     *
-     * @return The value of includeTagDeleted
-     */
     public Boolean getIncludeTagDeleted() {
         return includeTagDeleted;
     }
 
-    /**
-     * Include items with the `deleted` tag set in search results
-     *
-     * @param includeTagDeleted The boolean to set includeTagDeleted to
-     */
-    @GraphQLInputField(name = "includeTagDeleted", description = "Include items with the `deleted` tag set in search results")
+    @GraphQLInputField(name = GqlConstants.INCLUDE_TAG_DELETED, description = "Include items with the `deleted` tag set in search results")
     public void setIncludeTagDeleted(Boolean includeTagDeleted) {
         this.includeTagDeleted = includeTagDeleted;
     }
 
-    /**
-     * Gets the value of includeTagMuted.
-     *
-     * @return the includeTagMuted value
-     */
     public Boolean getIncludeTagMuted() {
         return includeTagMuted;
     }
 
-    /**
-     * Include items with the `muted` tag set in search results.
-     *
-     * @param includeTagMuted the boolean to set
-     */
-    @GraphQLInputField(name = "includeTagMuted", description = "Include items with the `muted` tag set in search results")
+    @GraphQLInputField(name = GqlConstants.INCLUDE_TAG_MUTED, description = "Include items with the `muted` tag set in search results")
     public void setIncludeTagMuted(Boolean includeTagMuted) {
         this.includeTagMuted = includeTagMuted;
     }
 
-    /**
-     * Gets the value of allowableTaskStatus.
-     *
-     * @return the allowableTaskStatus value setting
-     */
     public String getAllowableTaskStatus() {
         return allowableTaskStatus;
     }
 
-    /**
-     * Comma separated list of allowable Task statuses. Valid values : `NEED`, `INPR`, `WAITING`, `DEFERRED`, `COMP`.
-     *
-     * @param allowableTaskStatus The comma separated values for allowableTaskStatus to set
-     */
-    @GraphQLInputField(name = "allowableTaskStatus", description = "Comma separated list of allowable Task statuses. Valid values : `NEED`, `INPR`, `WAITING`, `DEFERRED`, `COMP`")
+    @GraphQLInputField(name = GqlConstants.ALLOWABLE_TASK_STATUS, description = "Comma separated list of allowable Task statuses. Valid values : `NEED`, `INPR`, `WAITING`, `DEFERRED`, `COMP`")
     public void setAllowableTaskStatus(String allowableTaskStatus) {
         this.allowableTaskStatus = allowableTaskStatus;
     }
 
-    /**
-     * Gets the value of calItemExpandStart.
-     *
-     * @return the calItemExpandStart value
-     */
     public Long getCalItemExpandStart() {
         return calItemExpandStart;
     }
 
-    /**
-     * Start time in milliseconds for the range to `includeMemberOf` instances for calendar items.
-     *
-     * @param calItemExpandStart the calItemExpandStart value to set
-     */
-    @GraphQLInputField(name = "calItemExpandStart", description="Start time in milliseconds for the range to `includeMemberOf` instances for calendar items. If `calExpandInstStart` and `calExpandInstEnd` are specified, and the search types `includeMemberOf` calendar item types (e.g. appointment), then the search results `includeMemberOf` the instances for calendar items within that range in the form described in the description of the response. ***IMPORTANT NOTE: Calendar Items that have no instances within that range are COMPLETELY EXCLUDED from the results. Calendar Items with no data (such as Tasks with no date specified) are included, but with no instance information***")
+    @GraphQLInputField(name = GqlConstants.CALENDAR_ITEM_EXPANDED_START, description="Start time in milliseconds for the range to `includeMemberOf` instances for calendar items. If `calExpandInstStart` and `calExpandInstEnd` are specified, and the search types `includeMemberOf` calendar item types (e.g. appointment), then the search results `includeMemberOf` the instances for calendar items within that range in the form described in the description of the response. ***IMPORTANT NOTE: Calendar Items that have no instances within that range are COMPLETELY EXCLUDED from the results. Calendar Items with no data (such as Tasks with no date specified) are included, but with no instance information***")
     public void setCalItemExpandStart(Long calItemExpandStart) {
         this.calItemExpandStart = calItemExpandStart;
     }
 
-    /**
-     * Gets the value of calItemExpandEnd.
-     *
-     * @return the calItemExpandEnd value
-     */
     public Long getCalItemExpandEnd() {
         return calItemExpandEnd;
     }
 
-    /**
-     * Time in milliseconds to end the span of time started by `calItemExpandStart` for calendar items from.
-     *
-     * @param calItemExpandEnd The calItemExpandEnd value to set
-     */
-    @GraphQLInputField(name = "calItemExpandEnd", description="End time in milliseconds for the range to `includeMemberOf` instances for calendar items from.")
+    @GraphQLInputField(name = GqlConstants.CALENDAR_ITEM_EXPANDED_END, description="End time in milliseconds for the range to `includeMemberOf` instances for calendar items from.")
     public void setCalItemExpandEnd(Long calItemExpandEnd) {
         this.calItemExpandEnd = calItemExpandEnd;
     }
 
-    /**
-     * Gets the value of query.
-     *
-     * @return The query value
-     */
     @GraphQLNonNull
     public String getQuery() {
         return query;
     }
 
-    /**
-     * Query string to use for the search.
-     *
-     * @param query The query string to use
-     */
-    @GraphQLInputField(name = "query", description="Query string to use for the search")
+    @GraphQLInputField(name = GqlConstants.QUERY, description="Query string to use for the search")
     public void setQuery(String query) {
         this.query = query;
     }
 
-    /**
-     * Gets the value of inDumpster.
-     *
-     * @return The inDumpster value
-     */
     public Boolean getInDumpster() {
         return inDumpster;
     }
 
-    /**
-     * Searches in the dumpster data instead of live data.
-     *
-     * @param inDumpster The inDumpster value to set
-     */
-    @GraphQLInputField(name = "inDumpster", description="Search dumpster data instead of live data.")
+    @GraphQLInputField(name = GqlConstants.IN_DUMPSTER, description="Search dumpster data instead of live data.")
     public void setInDumpster(Boolean inDumpster) {
         this.inDumpster = inDumpster;
     }
 
-    /**
-     * Gets the value of searchTypes.
-     *
-     * @return The searchTypes value
-     */
     @GraphQLIgnore
     public String getSearchTypes() {
         return searchTypes;
     }
 
-    /**
-     * Set a comma separated list of search types.<br>
-     * Legal values are: conversation, message, contact, appointment, task, wiki, document.
-     *
-     * @param searchTypes The searchTypes string to set
-     */
     @GraphQLIgnore
-    @GraphQLInputField(name = "searchTypes", description="Comma separated list of search types. Legal values are: conversation, message, contact, appointment, task, wiki, document")
     public void setSearchTypes(String searchTypes) {
         this.searchTypes = searchTypes;
     }
 
-    /**
-     * Gets the value of groupBy.
-     *
-     * @return The groupBy value
-     */
     public String getGroupBy() {
         return groupBy;
     }
 
-    /**
-     * Deprecated.  Use `searchTypes` instead.
-     *
-     * @param groupBy the groupBy to set
-     */
     @Deprecated
-    @GraphQLInputField(name = "groupBy", description="Deprecated.  Use `searchTypes` instead")
+    @GraphQLInputField(name = GqlConstants.GROUP_BY, description="Deprecated.  Use `searchTypes` instead")
     public void setGroupBy(String groupBy) {
         this.groupBy = groupBy;
     }
 
-    /**
-     * Gets the value of quick.
-     *
-     * @return the quick
-     */
     public Boolean getQuick() {
         return quick;
     }
 
-    /**
-     * Setting for searches to bypass indexing before search.
-     *
-     * @param quick The quick boolean to set
-     */
-    @GraphQLInputField(name = "quick", description="For performance reasons, skip indexing before search which lowers latencies. i.e. recent messages may not be included in the search results.")
+    @GraphQLInputField(name = GqlConstants.QUICK, description="For performance reasons, skip indexing before search which lowers latencies. i.e. recent messages may not be included in the search results.")
     public void setQuick(Boolean quick) {
         this.quick = quick;
     }
 
-    /**
-     * Gets the value of sortBy.
-     *
-     * @return the sortBy
-     */
     public String getSortBy() {
         return sortBy;
     }
 
-    /**
-     * Sets sort by value.<br>
-     * Possible values: `none, dateAsc, dateDesc, subjAsc, subjDesc, nameAsc, nameDesc,
-     * rcptAsc, rcptDesc, attachAsc, attachDesc, flagAsc, flagDesc, priorityAsc, priorityDesc, idAsc, idDesc,
-     * readAsc, readDesc`.
-     *
-     * @param sortBy The sortBy to set
-     */
-    @GraphQLInputField(name = "sortBy", description="SortBy setting. Possible values: `none, dateAsc, dateDesc, subjAsc, subjDesc, nameAsc, nameDesc, rcptAsc, rcptDesc, attachAsc, attachDesc, flagAsc, flagDesc, priorityAsc, priorityDesc, idAsc, idDesc, readAsc, readDesc`. If `sortBy` is \"none\" then cursors MUST NOT be used, and some searches are impossible (searches that require intersection of complex sub-ops). Server will throw an IllegalArgumentException if the search is invalid. ADDITIONAL SORT MODES FOR TASKS: valid only if types=\"task\" (and task alone): `taskDueAsc, taskDueDesc, taskStatusAsc, taskStatusDesc, taskPercCompletedAsc, taskPercCompletedDesc`")
+    @GraphQLInputField(name = GqlConstants.SORT_BY, description="SortBy setting. Possible values: `none, dateAsc, dateDesc, subjAsc, subjDesc, nameAsc, nameDesc, rcptAsc, rcptDesc, attachAsc, attachDesc, flagAsc, flagDesc, priorityAsc, priorityDesc, idAsc, idDesc, readAsc, readDesc`. If `sortBy` is \"none\" then cursors MUST NOT be used, and some searches are impossible (searches that require intersection of complex sub-ops). Server will throw an IllegalArgumentException if the search is invalid. ADDITIONAL SORT MODES FOR TASKS: valid only if types=\"task\" (and task alone): `taskDueAsc, taskDueDesc, taskStatusAsc, taskStatusDesc, taskPercCompletedAsc, taskPercCompletedDesc`")
     public void setSortBy(String sortBy) {
         this.sortBy = sortBy;
     }
 
-    /**
-     * Gets the value of fetch.
-     *
-     * @return The fetch value
-     */
     public String getFetch() {
         return fetch;
     }
 
-    /**
-     * Setting for hit expansion.
-     *
-     * @param fetch The fetch value to set
-     */
-    @GraphQLInputField(name = "fetch", description="Select setting for hit expansion. `1` or `first`: first hit expanded inline (messages only at present); `{item-id}`: only the message with the given {item-id} is expanded inline; `{item-id-1,item-id-2,...,item-id-n}`: messages with ids in the comma-separated list will be expanded; `all`: all messages are expanded inline; `!`: only the first message in the conversation will be expanded, whether it's a hit or not; `u` or `unread`: all unread hits are expanded; `u1` or `unread-first`: any unread hits are expanded, otherwise the first hit is expanded.; `u1!`: any unread hits are expanded, otherwise the first hit and the first message are expanded (those may be the same); `hits`: all hits are expanded; `hits!`: all hits are expanded if there are any, otherwise the first message is expanded; wantHtml: true, is also specified, inlined hits will return HTML parts if available; if markRead: true, is also specified, inlined hits will be marked as read; if neuterImages: false, is also specified, images in inlined HTML parts will not be \"neutered\";  if `header`s are requested, any matching headers are included in inlined message hits; if max=\"{max-inlined-length}\" is specified, inlined body content in limited to the given length; if the part is truncated, truncated=\"1\" is specified on the `mp` in question")
+    @GraphQLInputField(name = GqlConstants.FETCH, description="Select setting for hit expansion. `1` or `first`: first hit expanded inline (messages only at present); `{item-id}`: only the message with the given {item-id} is expanded inline; `{item-id-1,item-id-2,...,item-id-n}`: messages with ids in the comma-separated list will be expanded; `all`: all messages are expanded inline; `!`: only the first message in the conversation will be expanded, whether it's a hit or not; `u` or `unread`: all unread hits are expanded; `u1` or `unread-first`: any unread hits are expanded, otherwise the first hit is expanded.; `u1!`: any unread hits are expanded, otherwise the first hit and the first message are expanded (those may be the same); `hits`: all hits are expanded; `hits!`: all hits are expanded if there are any, otherwise the first message is expanded; wantHtml: true, is also specified, inlined hits will return HTML parts if available; if markRead: true, is also specified, inlined hits will be marked as read; if neuterImages: false, is also specified, images in inlined HTML parts will not be \"neutered\";  if `header`s are requested, any matching headers are included in inlined message hits; if max=\"{max-inlined-length}\" is specified, inlined body content in limited to the given length; if the part is truncated, truncated=\"1\" is specified on the `mp` in question")
     public void setFetch(String fetch) {
         this.fetch = fetch;
     }
 
-    /**
-     * Gets the value of markRead.
-     *
-     * @return The markRead value
-     */
     public Boolean getMarkRead() {
         return markRead;
     }
 
-    /**
-     * Sets inlined hits which will be marked as read if true.
-     *
-     * @param markRead The markRead to set
-     */
-    @GraphQLInputField(name = "markRead", description="Inlined hits will be marked as read")
+    @GraphQLInputField(name = GqlConstants.MARK_READ, description="Inlined hits will be marked as read")
     public void setMarkRead(Boolean markRead) {
         this.markRead = markRead;
     }
 
-    /**
-     * Gets the value of maxInlinedLength.
-     *
-     * @return the maxInlinedLength
-     */
     public Integer getMaxInlinedLength() {
         return maxInlinedLength;
     }
 
-    /**
-     * Limits inlined body content.
-     *
-     * @param maxInlinedLength The maxInlinedLength to set
-     */
-    @GraphQLInputField(name = "maxInlinedLength", description="Limits inlined body content. If specified, inlined body content is limited to the given length; if the part is truncated, truncated=\"1\" is specified on the `messagePartHits` in question")
+    @GraphQLInputField(name = GqlConstants.MAX_INLINED_LENGTH, description="Limits inlined body content. If specified, inlined body content is limited to the given length; if the part is truncated, truncated=\"1\" is specified on the `messagePartHits` in question")
     public void setMaxInlinedLength(Integer maxInlinedLength) {
         this.maxInlinedLength = maxInlinedLength;
     }
 
-    /**
-     * Gets the value of wantHtml.
-     *
-     * @return The wantHtml value
-     */
     public Boolean getWantHtml() {
         return wantHtml;
     }
 
-    /**
-     * Setting to return HTML parts if available, from inlined hits.
-     *
-     * @param wantHtml The wantHtml boolean to set
-     */
-    @GraphQLInputField(name = "wantHtml", description="Inlined hits to return HTML parts if available")
+    @GraphQLInputField(name = GqlConstants.WANT_HTML, description="Inlined hits to return HTML parts if available")
     public void setWantHtml(Boolean wantHtml) {
         this.wantHtml = wantHtml;
     }
 
-    /**
-     * Gets the value of needCanExpand.
-     *
-     * @return The needCanExpand value
-     */
     public Boolean getNeedCanExpand() {
         return needCanExpand;
     }
 
-    /**
-     * Setting for expanding groups.
-     *
-     * @param needCanExpand the needCanExpand to set
-     */
-    @GraphQLInputField(name = "needCanExpand", description="If `needExp` is set in the request, two additional flags may be included in `emails` results elements for messages returned inline. (1) `isGroup`: set if the email address is a group. (2) `exp`: present only when `isGroup` set to true. Unset if the authenticated user does not have permission to expand group members")
+    @GraphQLInputField(name = GqlConstants.NEED_CAN_EXPAND, description="If `needExp` is set in the request, two additional flags may be included in `emails` results elements for messages returned inline. (1) `isGroup`: set if the email address is a group. (2) `exp`: present only when `isGroup` set to true. Unset if the authenticated user does not have permission to expand group members")
     public void setNeedCanExpand(Boolean needCanExpand) {
         this.needCanExpand = needCanExpand;
     }
 
-    /**
-     * Gets the value of neuterImages.
-     *
-     * @return The neuterImages value
-     */
     public Boolean getNeuterImages() {
         return neuterImages;
     }
 
-    /**
-     * Setting to stop images in inlined HTML parts.
-     *
-     * @param neuterImages The neuterImages to set
-     */
-    @GraphQLInputField(name = "neuterImages", description="Set to false to stop images in inlined HTML parts from being \"neutered\"")
+    @GraphQLInputField(name = GqlConstants.NEUTER_IMAGES, description="Set to false to stop images in inlined HTML parts from being \"neutered\"")
     public void setNeuterImages(Boolean neuterImages) {
         this.neuterImages = neuterImages;
     }
 
-    /**
-     * Gets the value of wantRecipients.
-     *
-     * @return The wantRecipients
-     */
     public WantRecipsSetting getWantRecipients() {
         return wantRecipients;
     }
 
-    /**
-     * Setting to include recipients.
-     *
-     * @param wantRecipients The wantRecipients value to set
-     */
-    @GraphQLInputField(name = "wantRecipients", description="Want recipients setting. If true, sent messages that contain the \"To:\" recipients instead of the sender. Returned conversations whose first hit was sent by the user will contain that hit's \"To:\" recipients instead of the conversation's sender list")
+    @GraphQLInputField(name = GqlConstants.WANT_RECEPIENTS, description="Want recipients setting. If true, sent messages that contain the \"To:\" recipients instead of the sender. Returned conversations whose first hit was sent by the user will contain that hit's \"To:\" recipients instead of the conversation's sender list")
     public void setWantRecipients(WantRecipsSetting wantRecipients) {
         this.wantRecipients = wantRecipients;
     }
 
-    /**
-     * Gets the value of prefetch.
-     *
-     * @return the prefetch
-     */
     public Boolean getPrefetch() {
         return prefetch;
     }
 
-    /**
-     * Prefetch setting.
-     *
-     * @param prefetch The prefetch boolean to set
-     */
-    @GraphQLInputField(name = "prefetch", description="Prefetch")
+    @GraphQLInputField(name = GqlConstants.PREFETCH, description="Prefetch")
     public void setPrefetch(Boolean prefetch) {
         this.prefetch = prefetch;
     }
 
-    /**
-     * Gets the value of resultMode.
-     *
-     * @return The resultMode
-     */
     public String getResultMode() {
         return resultMode;
     }
 
-    /**
-     * Setting specifies the type of result. NORMAL [default]: Everything, IDS: Only IDs.
-     *
-     * @param resultMode The resultMode to set
-     */
-    @GraphQLInputField(name = "resultMode", description="Specifies the type of result. NORMAL [default]: Everything, IDS: Only IDs")
+    @GraphQLInputField(name = GqlConstants.RESULT_MODE, description="Specifies the type of result. NORMAL [default]: Everything, IDS: Only IDs")
     public void setResultMode(String resultMode) {
         this.resultMode = resultMode;
     }
 
-    /**
-     * Gets the value of fullConversation.
-     *
-     * @return The fullConversation value
-     */
     public ZmBoolean getFullConversation() {
         return ZmBoolean.fromBool(fullConversation);
     }
 
-    /**
-     * The setting for full conversations.
-     *
-     * @param fullConversation The fullConversation boolean to set
-     */
-    @GraphQLInputField(name = "fullConversation", description="Full conversations")
+    @GraphQLInputField(name = GqlConstants.FULL_CONVERSATION, description="Full conversations")
     public void setFullConversation(Boolean fullConversation) {
         this.fullConversation = fullConversation;
     }
 
-    /**
-     * Gets the value of field.
-     *
-     * @return The field value
-     */
     public String getField() {
         return field;
     }
 
-    /**
-     * The setting of the field to search on, by default, searches the CONTENT field.<br>
-     * 'content:' [the default] or 'subject:', etc.
-     *
-     * @param field The field value to set
-     */
-    @GraphQLInputField(name = "field", description="By default, searches the CONTENT field. 'content:' [the default] or 'subject:', etc.")
+    @GraphQLInputField(name = GqlConstants.FIELD, description="By default, searches the CONTENT field. 'content:' [the default] or 'subject:', etc.")
     public void setField(String field) {
         this.field = field;
     }
 
-    /**
-     * Gets the value of limit.
-     *
-     * @return The limit value
-     */
     public Integer getLimit() {
         return limit;
     }
 
-    /**
-     * The maximum number of results to return. It defaults to 10 if not specified,
-     * and is capped by 1000
-     *
-     * @param limit The limit value to set
-     */
-    @GraphQLInputField(name = "limit", description="The maximum number of results to return. It defaults to 10 if not specified, and is capped by 1000")
+    @GraphQLInputField(name = GqlConstants.LIMIT, description="The maximum number of results to return. It defaults to 10 if not specified, and is capped by 1000")
     public void setLimit(Integer limit) {
         this.limit = limit;
     }
 
-    /**
-     * Gets the value of offset.
-     *
-     * @return The offset value
-     */
     public Integer getOffset() {
         return offset;
     }
 
-    /**
-     * Specifies the 0-based offset into the results list to return as the first result for
-     * this search operation. For example, limit=10 offset=30 will return the 31st through 40th
-     * results inclusive.
-     *
-     * @param offset The offset value to set
-     */
-    @GraphQLInputField(name = "offset", description="Specifies the 0-based offset into the results list to return as the first result for this search operation. For example, limit=10 offset=30 will return the 31st through 40th results inclusive.")
+    @GraphQLInputField(name = GqlConstants.OFFSET, description="Specifies the 0-based offset into the results list to return as the first result for this search operation. For example, limit=10 offset=30 will return the 31st through 40th results inclusive.")
     public void setOffset(Integer offset) {
         this.offset = offset;
     }
 
-    /**
-     * Gets the value of calTz.
-     *
-     * @return The calTz value
-     */
     public CalTZInfo getCalTz() {
         return calTz;
     }
 
-    /**
-     * Sets the timezone specification.
-     *
-     * @param calTz The CalTZInfo value to set
-     */
-    @GraphQLInputField(name = "calTz", description="Timezone specification")
+    @GraphQLInputField(name = GqlConstants.CALENDAR_TIME_ZONE, description="Timezone specification")
     public void setCalTz(CalTZInfo calTz) {
         this.calTz = calTz;
     }
 
-    /**
-     * Gets the value of locale.
-     *
-     * @return The locale value
-     */
     public String getLocale() {
         return locale;
     }
 
-    /**
-     * Sets the client locale identification.
-     * Value is of the form LL-CC[-V+].
-     * - LL 2 character language code
-     * - CC is 2 character country code
-     * - V+ is optional variant identifier string
-     *
-     * @param locale The locale to set
-     */
-    @GraphQLInputField(name = "locale", description="Client locale identification. Value is of the form LL-CC[-V+]. LL 2 character language code; CC is 2 character country code; V+ is optional variant identifier string")
+    @GraphQLInputField(name = GqlConstants.LOCALE, description="Client locale identification. Value is of the form LL-CC[-V+]. LL 2 character language code; CC is 2 character country code; V+ is optional variant identifier string")
     public void setLocale(String locale) {
         this.locale = locale;
     }
 
-    /**
-     * Gets the value of cursor.
-     *
-     * @return The cursor value
-     */
     public CursorInfo getCursor() {
         return cursor;
     }
 
-    /**
-     * Cursor specification to use.
-     *
-     * @param cursor The CursorInfo value to set
-     */
-    @GraphQLInputField(name = "cursor", description="Cursor specification.")
+    @GraphQLInputField(name = GqlConstants.CURSOR, description="Cursor specification.")
     public void setCursor(CursorInfo cursor) {
         this.cursor = cursor;
     }
 
-    /**
-     * Gets the value of msgContent.
-     *
-     * @return the msgContent
-     */
     public MsgContent getMsgContent() {
         return msgContent;
     }
 
-    /**
-     * Message content the client expects in response.
-     *
-     * @param the msgContent to set
-     */
-    @GraphQLInputField(name = "msgContent", description="Message Content the client expects in response. full: The complete message; original: Only the Message and not quoted text; both: The complete message and also this message without quoted text ")
+    @GraphQLInputField(name = GqlConstants.MSG_CONTENT, description="Message Content the client expects in response. full: The complete message; original: Only the Message and not quoted text; both: The complete message and also this message without quoted text ")
     public void setMsgContent(MsgContent msgContent) {
         this.msgContent = msgContent;
     }
 
-    /**
-     * Gets the value of includeMemberOf.
-     *
-     * @return the includeMemberOf setting value
-     */
     public Boolean getIncludeMemberOf() {
         return includeMemberOf;
     }
 
-    /**
-     * List the contact groups this contact is a member of.
-     *
-     * @param includeMemberOf Boolean to list the contact groups this contact is a member of
-     */
-    @GraphQLInputField(name = "includeMemberOf", description="Include the list of contact groups this contact is a member of. Performance penalty associated with computing this information.")
+    @GraphQLInputField(name = GqlConstants.INCLUDE_MEMBER_OF, description="Include the list of contact groups this contact is a member of. Performance penalty associated with computing this information.")
     public void setIncludeMemberOf(Boolean includeMemberOf) {
         this.includeMemberOf = includeMemberOf;
     }
 
-    /**
-     * Gets the value of headers.
-     *
-     * @return the headers
-     */
     public List<AttributeName> getHeaders() {
         return headers;
     }
 
-    /**
-     * List of requested header's to be included in inlined message hits.
-     *
-     * @param headers the list of headers to be included in inlined message hits
-     */
-    @GraphQLInputField(name = "headers", description="List of requested header's to be included in inlined message hits")
+    @GraphQLInputField(name = GqlConstants.HEADERS, description="List of requested header's to be included in inlined message hits")
     public void setHeaders(List<AttributeName> headers) {
         this.headers = headers;
     }

--- a/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
@@ -25,6 +25,7 @@ import com.zimbra.soap.type.MsgContent;
 import com.zimbra.soap.type.WantRecipsSetting;
 import com.zimbra.soap.type.ZmBoolean;
 
+import io.leangen.graphql.annotations.GraphQLIgnore;
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLNonNull;
 import io.leangen.graphql.annotations.types.GraphQLType;
@@ -48,6 +49,7 @@ public class GQLSearchRequestInput {
     protected Long calItemExpandEnd;
     protected String query;
     protected Boolean inDumpster;
+    @GraphQLIgnore
     protected String searchTypes;
     protected String groupBy;
     protected Boolean quick;
@@ -211,6 +213,7 @@ public class GQLSearchRequestInput {
      *
      * @return The searchTypes value
      */
+    @GraphQLIgnore
     public String getSearchTypes() {
         return searchTypes;
     }
@@ -221,6 +224,7 @@ public class GQLSearchRequestInput {
      *
      * @param searchTypes The searchTypes string to set
      */
+    @GraphQLIgnore
     @GraphQLInputField(name = "searchTypes", description="Comma separated list of search types. Legal values are: conversation, message, contact, appointment, task, wiki, document")
     public void setSearchTypes(String searchTypes) {
         this.searchTypes = searchTypes;

--- a/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLSearchRequestInput.java
@@ -120,13 +120,12 @@ public class GQLSearchRequestInput {
         this.calItemExpandEnd = calItemExpandEnd;
     }
 
-    @GraphQLNonNull
     public String getQuery() {
         return query;
     }
 
     @GraphQLInputField(name = GqlConstants.QUERY, description="Query string to use for the search")
-    public void setQuery(String query) {
+    public void setQuery(@GraphQLNonNull String query) {
         this.query = query;
     }
 

--- a/src/java/com/zimbra/graphql/models/outputs/GQLConversationSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLConversationSearchResponse.java
@@ -1,0 +1,72 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.outputs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Iterables;
+import com.zimbra.soap.mail.type.ConversationHitInfo;
+import com.zimbra.soap.type.SearchHit;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLConversationSearchResponse class.<br>
+ * Contains search response data for a conversation search.
+ * @see com.zimbra.soap.mail.message.SearchResponse
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.inputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name = "GQLConversationSearchResponse",
+    description = "Search response data for a conversation search")
+public class GQLConversationSearchResponse extends GQLSearchResponse {
+
+    @Override
+    public void setSearchHits(Iterable<SearchHit> setHits) {
+        this.searchHits.clear();
+        if (setHits != null) {
+            final List<ConversationHitInfo> hits = new ArrayList<ConversationHitInfo>();
+            for (final SearchHit hit : setHits) {
+                if (hit.getClass().equals(ConversationHitInfo.class)) {
+                    hits.add((ConversationHitInfo) hit);
+                }
+            }
+            Iterables.addAll(this.searchHits, hits);
+        }
+    }
+
+    public GQLConversationSearchResponse addSearchHit(ConversationHitInfo searchHit) {
+        this.searchHits.add(searchHit);
+        return this;
+    }
+
+    @Override
+    @GraphQLQuery(name="searchHits", description="Search hits for conversations")
+    public List<ConversationHitInfo> getSearchHits() {
+        final List<ConversationHitInfo> hits = new ArrayList<ConversationHitInfo>();
+        for (final SearchHit hit : searchHits) {
+            if (hit instanceof ConversationHitInfo) {
+                hits.add((ConversationHitInfo) hit);
+            }
+        }
+        return hits;
+    }
+}

--- a/src/java/com/zimbra/graphql/models/outputs/GQLConversationSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLConversationSearchResponse.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.Iterables;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.soap.mail.type.ConversationHitInfo;
 import com.zimbra.soap.type.SearchHit;
 
@@ -35,21 +36,14 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name = "GQLConversationSearchResponse",
-    description = "Search response data for a conversation search")
+@GraphQLType(name = GqlConstants.CONVERSATION_SEARCH_RESPONSE, description = "Search response data for a conversation search")
 public class GQLConversationSearchResponse extends GQLSearchResponse {
 
     @Override
     public void setSearchHits(Iterable<SearchHit> setHits) {
         this.searchHits.clear();
         if (setHits != null) {
-            final List<ConversationHitInfo> hits = new ArrayList<ConversationHitInfo>();
-            for (final SearchHit hit : setHits) {
-                if (hit.getClass().equals(ConversationHitInfo.class)) {
-                    hits.add((ConversationHitInfo) hit);
-                }
-            }
-            Iterables.addAll(this.searchHits, hits);
+            Iterables.addAll(this.searchHits, setHits);
         }
     }
 
@@ -59,7 +53,7 @@ public class GQLConversationSearchResponse extends GQLSearchResponse {
     }
 
     @Override
-    @GraphQLQuery(name="searchHits", description="Search hits for conversations")
+    @GraphQLQuery(name=GqlConstants.SEARCH_HITS, description="Search hits for conversations")
     public List<ConversationHitInfo> getSearchHits() {
         final List<ConversationHitInfo> hits = new ArrayList<ConversationHitInfo>();
         for (final SearchHit hit : searchHits) {

--- a/src/java/com/zimbra/graphql/models/outputs/GQLMessageSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLMessageSearchResponse.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.collect.Iterables;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.soap.mail.type.MessageHitInfo;
 import com.zimbra.soap.type.SearchHit;
 
@@ -35,21 +36,14 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name = "GQLMessageSearchResponse", description = "Search response data for a message search")
+@GraphQLType(name = GqlConstants.MESSAGE_SEARCH_RESPONSE, description = "Search response data for a message search")
 public class GQLMessageSearchResponse extends GQLSearchResponse {
 
     @Override
     public void setSearchHits(Iterable<SearchHit> setHits) {
         this.searchHits.clear();
         if (setHits != null) {
-            final List<MessageHitInfo> hits = new ArrayList<MessageHitInfo>();
-
-            for (final SearchHit hit : setHits) {
-                if (hit.getClass().equals(MessageHitInfo.class)) {
-                    hits.add((MessageHitInfo) hit);
-                }
-            }
-            Iterables.addAll(this.searchHits, hits);
+            Iterables.addAll(this.searchHits, setHits);
         }
     }
 
@@ -59,7 +53,7 @@ public class GQLMessageSearchResponse extends GQLSearchResponse {
     }
 
     @Override
-    @GraphQLQuery(name="searchHits", description="Search hits for messages")
+    @GraphQLQuery(name=GqlConstants.SEARCH_HITS, description="Search hits for messages")
     public List<MessageHitInfo> getSearchHits() {
         final List<MessageHitInfo> hits = new ArrayList<MessageHitInfo>();
         for (final SearchHit hit : searchHits) {

--- a/src/java/com/zimbra/graphql/models/outputs/GQLMessageSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLMessageSearchResponse.java
@@ -1,0 +1,73 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.outputs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Iterables;
+import com.zimbra.soap.mail.type.MessageHitInfo;
+import com.zimbra.soap.type.SearchHit;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLMessageSearchResponse class.<br>
+ * Contains search response data for a message search.
+ * @see com.zimbra.soap.mail.message.SearchResponse
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.inputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name = "GQLMessageSearchResponse", description = "Search response data for a message search")
+public class GQLMessageSearchResponse extends GQLSearchResponse {
+
+    @Override
+    public void setSearchHits(Iterable<SearchHit> setHits) {
+        this.searchHits.clear();
+        if (setHits != null) {
+            final List<MessageHitInfo> hits = new ArrayList<MessageHitInfo>();
+
+            for (final SearchHit hit : setHits) {
+                if (hit.getClass().equals(MessageHitInfo.class)) {
+                    hits.add((MessageHitInfo) hit);
+                }
+            }
+            Iterables.addAll(this.searchHits, hits);
+        }
+    }
+
+    public GQLMessageSearchResponse addSearchHit(MessageHitInfo searchHit) {
+        this.searchHits.add(searchHit);
+        return this;
+    }
+
+    @Override
+    @GraphQLQuery(name="searchHits", description="Search hits for messages")
+    public List<MessageHitInfo> getSearchHits() {
+        final List<MessageHitInfo> hits = new ArrayList<MessageHitInfo>();
+        for (final SearchHit hit : searchHits) {
+            if (hit instanceof MessageHitInfo) {
+                hits.add((MessageHitInfo) hit);
+            }
+        }
+        return hits;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/models/outputs/GQLSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSearchResponse.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.soap.type.BaseQueryInfo;
 import com.zimbra.soap.type.SearchHit;
 import com.zimbra.soap.type.ZmBoolean;
@@ -37,112 +38,32 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  * @package com.zimbra.graphql.models.inputs
  * @copyright Copyright © 2018
  */
-@GraphQLType(name = "GQLSearchResponse", description = "Search response data")
+@GraphQLType(name = GqlConstants.SEARCH_RESPONSE, description = "Search response data")
 public class GQLSearchResponse {
 
-    /**
-     * What to sort by.
-     *
-     * Default is "dateDesc".
-     *
-     * Possible values:
-     * none|dateAsc|dateDesc|subjAsc|subjDesc|nameAsc|nameDesc|rcptAsc|
-     * rcptDesc|attachAsc|attachDesc|flagAsc|flagDesc|priorityAsc|
-     * priorityDesc|idAsc|idDesc|readAsc|readDesc
-     *
-     * If sort-by is "none" then cursors MUST NOT be used, and some searches
-     * are impossible (searches that require intersection of complex sub-ops).
-     * Server will throw an IllegalArgumentException if the search is invalid.
-     *
-     * ADDITIONAL SORT MODES FOR TASKS: valid only if types="task" (and task alone):
-     * taskDueAsc|taskDueDesc|taskStatusAsc|taskStatusDesc|taskPercCompletedAsc|
-     * taskPercCompletedDesc
-     */
 	protected String sortBy;
-
-    /**
-     * Offset - an integer specifying the 0-based offset.
-     *
-     * An integer specifying the 0-based offset into the results list returned
-     * as the first result for this search operation.
-     */
 	protected Integer queryOffset;
-
-    /**
-     * Set if there are more search results remaining.
-     */
 	protected ZmBoolean queryMore;
-
-    /**
-     * All messages in the response.
-     */
 	protected Long totalSize;
-
-    /**
-     * Search hits returned for the query.
-     */
     protected List<SearchHit> searchHits = Lists.newArrayList();
-
-    /**
-     * Info block.  Used to return general status information about your search.
-     *
-     * The wildcard element tells you about the status of wildcard
-     * expansions within your search.
-     *
-     * If expanded is set, then the wildcard was expanded and the matches
-     * are included in the search. If expanded is unset then the wildcard was not
-     * specific enough and therefore no wildcard matches are included
-     * (exact-match <b>is</b> included in results).
-     */
     protected List<BaseQueryInfo> queryInfos = Lists.newArrayList();
 
-    /**
-     * Constructor.
-     */
-    public GQLSearchResponse() {
-    }
-
-    /**
-     * Sets sortBy.
-     *
-     * @param sortBy
-     */
     public void setSortBy(String sortBy) {
         this.sortBy = sortBy;
     }
 
-    /**
-     * Sets queryOffset.
-     *
-     * @param queryOffset
-     */
     public void setQueryOffset(Integer queryOffset) {
         this.queryOffset = queryOffset;
     }
 
-    /**
-     * Sets queryMore.
-     *
-     * @param queryMore
-     */
     public void setQueryMore(Boolean queryMore) {
         this.queryMore = ZmBoolean.fromBool(queryMore);
     }
 
-    /**
-     * Sets totalSize.
-     *
-     * @param totalSize
-     */
     public void setTotalSize(Long totalSize) {
         this.totalSize = totalSize;
     }
 
-    /**
-     * Sets searchHits.
-     *
-     * @param searchHits
-     */
     public void setSearchHits(Iterable <SearchHit> searchHits) {
         this.searchHits.clear();
         if (searchHits != null) {
@@ -150,23 +71,11 @@ public class GQLSearchResponse {
         }
     }
 
-
-    /**
-     * Add a SearchHit value.
-     *
-     * @param searchHit
-     * @return this
-     */
     public GQLSearchResponse addSearchHit(SearchHit searchHit) {
         this.searchHits.add(searchHit);
         return this;
     }
 
-    /**
-     * Sets queryInfos.
-     *
-     * @param queryInfos
-     */
     public void setQueryInfos(Iterable <BaseQueryInfo> queryInfos) {
         this.queryInfos.clear();
         if (queryInfos != null) {
@@ -174,74 +83,37 @@ public class GQLSearchResponse {
         }
     }
 
-    /**
-     * Add a queryInfos value.
-     *
-     * @param queryInfo
-     * @return
-     */
     public GQLSearchResponse addQueryInfo(BaseQueryInfo queryInfo) {
         this.queryInfos.add(queryInfo);
         return this;
     }
 
-    /**
-     * Get the sortBy value.
-     *
-     * @return sortBy
-     */
-    @GraphQLQuery(name="sortBy", description="What to sort by. Default is \"dateDesc\". \n\nPossible values: \n" +
-        "`none`, `dateAsc`, `dateDesc`, `subjAsc`, `subjDesc`, `nameAsc`, `nameDesc`, `rcptAsc`, `rcptDesc`, `attachAsc`, `attachDesc`, `flagAsc`, `flagDesc`, `priorityAsc`, `priorityDesc`\n\nIf `sortBy` is \"none\" then cursors MUST NOT be used, and some searches are impossible (searches that require intersection of complex sub-ops). \nServer will throw an IllegalArgumentException if the search is invalid. \nADDITIONAL SORT MODES FOR TASKS: \nvalid only if types=\"task\" (and task alone): \n`taskDueAsc`, `taskDueDesc`, `taskStatusAsc`, `taskStatusDesc`, `taskPercCompletedAsc`, `taskPercCompletedDesc`")
+    @GraphQLQuery(name=GqlConstants.SORT_BY, description="What to sort by. Default is \"dateDesc\"")
     public String getSortBy() {
         return sortBy;
     }
 
-    /**
-     * Get the queryOffset value.
-     *
-     * @return queryOffset
-     */
-    @GraphQLQuery(name="queryOffset", description="Offset - an integer specifying the 0-based offset into the results list returned as the first result for this search operation.")
+    @GraphQLQuery(name=GqlConstants.QUERY_OFFSET, description="Offset - an integer specifying the 0-based offset into the results list returned as the first result for this search operation.")
     public Integer getQueryOffset() {
         return queryOffset;
     }
 
-    /**
-     * Get the queryMore value.
-     *
-     * @return queryMore
-     */
-    @GraphQLQuery(name="queryMore", description="Set if there are more search results remaining.")
+    @GraphQLQuery(name=GqlConstants.QUERY_MORE, description="Set if there are more search results remaining.")
     public Boolean getQueryMore() {
         return ZmBoolean.toBool(queryMore);
     }
 
-    /**
-     * Get the totalSize value.
-     *
-     * @return totalSize
-     */
-    @GraphQLQuery(name="totalSize", description="All messages")
+    @GraphQLQuery(name=GqlConstants.TOTAL_SIZE, description="All messages")
     public Long getTotalSize() {
         return totalSize;
     }
 
-    /**
-     * Get the queryInfos value.
-     *
-     * @return queryInfos
-     */
-    @GraphQLQuery(name="queryInfos", description="Info block. \nUsed to return general status information about your search. The `wildcard` element tells you about the status of `wildcard` expansions within your search. If `expanded` is set, then the `wildcard` was expanded and the matches are included in the search. If `expanded` is unset then the `wildcard` was not specific enough and therefore no `wildcard` matches are included (exact-match is included in results).")
+    @GraphQLQuery(name=GqlConstants.QUERY_INFOS, description="Info block. \nUsed to return general status information about your search. The `wildcard` element tells you about the status of `wildcard` expansions within your search. If `expanded` is set, then the `wildcard` was expanded and the matches are included in the search. If `expanded` is unset then the `wildcard` was not specific enough and therefore no `wildcard` matches are included (exact-match is included in results).")
     public List<BaseQueryInfo> getQueryInfos() {
         return Collections.unmodifiableList(queryInfos);
     }
 
-    /**
-     * Get the searchHits value.
-     *
-     * @return searchHits
-     */
-    @GraphQLQuery(name="searchHits", description="Search hits")
+    @GraphQLQuery(name=GqlConstants.SEARCH_HITS, description="Search hits")
     public List<? extends SearchHit> getSearchHits() {
         return Collections.unmodifiableList(searchHits);
     }

--- a/src/java/com/zimbra/graphql/models/outputs/GQLSearchResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSearchResponse.java
@@ -1,0 +1,249 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.outputs;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.zimbra.soap.type.BaseQueryInfo;
+import com.zimbra.soap.type.SearchHit;
+import com.zimbra.soap.type.ZmBoolean;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLSearchResponse class.<br>
+ * Contains search response data for a search.
+ * @see com.zimbra.soap.mail.message.SearchResponse
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.inputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name = "GQLSearchResponse", description = "Search response data")
+public class GQLSearchResponse {
+
+    /**
+     * What to sort by.
+     *
+     * Default is "dateDesc".
+     *
+     * Possible values:
+     * none|dateAsc|dateDesc|subjAsc|subjDesc|nameAsc|nameDesc|rcptAsc|
+     * rcptDesc|attachAsc|attachDesc|flagAsc|flagDesc|priorityAsc|
+     * priorityDesc|idAsc|idDesc|readAsc|readDesc
+     *
+     * If sort-by is "none" then cursors MUST NOT be used, and some searches
+     * are impossible (searches that require intersection of complex sub-ops).
+     * Server will throw an IllegalArgumentException if the search is invalid.
+     *
+     * ADDITIONAL SORT MODES FOR TASKS: valid only if types="task" (and task alone):
+     * taskDueAsc|taskDueDesc|taskStatusAsc|taskStatusDesc|taskPercCompletedAsc|
+     * taskPercCompletedDesc
+     */
+	protected String sortBy;
+
+    /**
+     * Offset - an integer specifying the 0-based offset.
+     *
+     * An integer specifying the 0-based offset into the results list returned
+     * as the first result for this search operation.
+     */
+	protected Integer queryOffset;
+
+    /**
+     * Set if there are more search results remaining.
+     */
+	protected ZmBoolean queryMore;
+
+    /**
+     * All messages in the response.
+     */
+	protected Long totalSize;
+
+    /**
+     * Search hits returned for the query.
+     */
+    protected List<SearchHit> searchHits = Lists.newArrayList();
+
+    /**
+     * Info block.  Used to return general status information about your search.
+     *
+     * The wildcard element tells you about the status of wildcard
+     * expansions within your search.
+     *
+     * If expanded is set, then the wildcard was expanded and the matches
+     * are included in the search. If expanded is unset then the wildcard was not
+     * specific enough and therefore no wildcard matches are included
+     * (exact-match <b>is</b> included in results).
+     */
+    protected List<BaseQueryInfo> queryInfos = Lists.newArrayList();
+
+    /**
+     * Constructor.
+     */
+    public GQLSearchResponse() {
+    }
+
+    /**
+     * Sets sortBy.
+     *
+     * @param sortBy
+     */
+    public void setSortBy(String sortBy) {
+        this.sortBy = sortBy;
+    }
+
+    /**
+     * Sets queryOffset.
+     *
+     * @param queryOffset
+     */
+    public void setQueryOffset(Integer queryOffset) {
+        this.queryOffset = queryOffset;
+    }
+
+    /**
+     * Sets queryMore.
+     *
+     * @param queryMore
+     */
+    public void setQueryMore(Boolean queryMore) {
+        this.queryMore = ZmBoolean.fromBool(queryMore);
+    }
+
+    /**
+     * Sets totalSize.
+     *
+     * @param totalSize
+     */
+    public void setTotalSize(Long totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    /**
+     * Sets searchHits.
+     *
+     * @param searchHits
+     */
+    public void setSearchHits(Iterable <SearchHit> searchHits) {
+        this.searchHits.clear();
+        if (searchHits != null) {
+            Iterables.addAll(this.searchHits,searchHits);
+        }
+    }
+
+
+    /**
+     * Add a SearchHit value.
+     *
+     * @param searchHit
+     * @return this
+     */
+    public GQLSearchResponse addSearchHit(SearchHit searchHit) {
+        this.searchHits.add(searchHit);
+        return this;
+    }
+
+    /**
+     * Sets queryInfos.
+     *
+     * @param queryInfos
+     */
+    public void setQueryInfos(Iterable <BaseQueryInfo> queryInfos) {
+        this.queryInfos.clear();
+        if (queryInfos != null) {
+            Iterables.addAll(this.queryInfos,queryInfos);
+        }
+    }
+
+    /**
+     * Add a queryInfos value.
+     *
+     * @param queryInfo
+     * @return
+     */
+    public GQLSearchResponse addQueryInfo(BaseQueryInfo queryInfo) {
+        this.queryInfos.add(queryInfo);
+        return this;
+    }
+
+    /**
+     * Get the sortBy value.
+     *
+     * @return sortBy
+     */
+    @GraphQLQuery(name="sortBy", description="What to sort by. Default is \"dateDesc\". \n\nPossible values: \n" +
+        "`none`, `dateAsc`, `dateDesc`, `subjAsc`, `subjDesc`, `nameAsc`, `nameDesc`, `rcptAsc`, `rcptDesc`, `attachAsc`, `attachDesc`, `flagAsc`, `flagDesc`, `priorityAsc`, `priorityDesc`\n\nIf `sortBy` is \"none\" then cursors MUST NOT be used, and some searches are impossible (searches that require intersection of complex sub-ops). \nServer will throw an IllegalArgumentException if the search is invalid. \nADDITIONAL SORT MODES FOR TASKS: \nvalid only if types=\"task\" (and task alone): \n`taskDueAsc`, `taskDueDesc`, `taskStatusAsc`, `taskStatusDesc`, `taskPercCompletedAsc`, `taskPercCompletedDesc`")
+    public String getSortBy() {
+        return sortBy;
+    }
+
+    /**
+     * Get the queryOffset value.
+     *
+     * @return queryOffset
+     */
+    @GraphQLQuery(name="queryOffset", description="Offset - an integer specifying the 0-based offset into the results list returned as the first result for this search operation.")
+    public Integer getQueryOffset() {
+        return queryOffset;
+    }
+
+    /**
+     * Get the queryMore value.
+     *
+     * @return queryMore
+     */
+    @GraphQLQuery(name="queryMore", description="Set if there are more search results remaining.")
+    public Boolean getQueryMore() {
+        return ZmBoolean.toBool(queryMore);
+    }
+
+    /**
+     * Get the totalSize value.
+     *
+     * @return totalSize
+     */
+    @GraphQLQuery(name="totalSize", description="All messages")
+    public Long getTotalSize() {
+        return totalSize;
+    }
+
+    /**
+     * Get the queryInfos value.
+     *
+     * @return queryInfos
+     */
+    @GraphQLQuery(name="queryInfos", description="Info block. \nUsed to return general status information about your search. The `wildcard` element tells you about the status of `wildcard` expansions within your search. If `expanded` is set, then the `wildcard` was expanded and the matches are included in the search. If `expanded` is unset then the `wildcard` was not specific enough and therefore no `wildcard` matches are included (exact-match is included in results).")
+    public List<BaseQueryInfo> getQueryInfos() {
+        return Collections.unmodifiableList(queryInfos);
+    }
+
+    /**
+     * Get the searchHits value.
+     *
+     * @return searchHits
+     */
+    @GraphQLQuery(name="searchHits", description="Search hits")
+    public List<? extends SearchHit> getSearchHits() {
+        return Collections.unmodifiableList(searchHits);
+    }
+
+}

--- a/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
@@ -17,6 +17,7 @@
 package com.zimbra.graphql.resolvers.impl;
 
 
+import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLSearchRequestInput;
@@ -52,7 +53,7 @@ public class SearchResolver {
 
     @GraphQLQuery(description = "Search for messages with the given properties.")
     public GQLMessageSearchResponse messageSearch(
-            @GraphQLNonNull @GraphQLArgument(name = "params") GQLSearchRequestInput searchInput,
+            @GraphQLNonNull @GraphQLArgument(name=GqlConstants.SEARCH_PARAMS, description="Input parameters for the search") GQLSearchRequestInput searchInput,
             @GraphQLRootContext RequestContext context
             ) throws ServiceException {
         return searchRepository.messageSearch(context, searchInput);
@@ -60,7 +61,7 @@ public class SearchResolver {
 
     @GraphQLQuery(description = "Search for conversations with the given properties.")
     public GQLConversationSearchResponse conversationSearch(
-            @GraphQLNonNull @GraphQLArgument(name = "params") GQLSearchRequestInput searchInput,
+            @GraphQLNonNull @GraphQLArgument(name=GqlConstants.SEARCH_PARAMS, description="Input parameters for the search") GQLSearchRequestInput searchInput,
             @GraphQLRootContext RequestContext context
             ) throws ServiceException {
         return searchRepository.conversationSearch(context, searchInput);

--- a/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
@@ -17,14 +17,12 @@
 package com.zimbra.graphql.resolvers.impl;
 
 
-import java.util.List;
-
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLSearchRequestInput;
+import com.zimbra.graphql.models.outputs.GQLConversationSearchResponse;
+import com.zimbra.graphql.models.outputs.GQLMessageSearchResponse;
 import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
-import com.zimbra.soap.mail.type.ConversationHitInfo;
-import com.zimbra.soap.mail.type.MessageHitInfo;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLNonNull;
@@ -52,16 +50,16 @@ public class SearchResolver {
         this.searchRepository = searchRepository;
     }
 
-    @GraphQLQuery(description = "Retrieves search results for the given properties.")
-    public List<MessageHitInfo> messageSearch(
+    @GraphQLQuery(description = "Search for messages with the given properties.")
+    public GQLMessageSearchResponse messageSearch(
             @GraphQLNonNull @GraphQLArgument(name = "params") GQLSearchRequestInput searchInput,
             @GraphQLRootContext RequestContext context
             ) throws ServiceException {
         return searchRepository.messageSearch(context, searchInput);
     }
 
-    @GraphQLQuery(description = "Retrieves search results for the given properties.")
-    public List<ConversationHitInfo> conversationSearch(
+    @GraphQLQuery(description = "Search for conversations with the given properties.")
+    public GQLConversationSearchResponse conversationSearch(
             @GraphQLNonNull @GraphQLArgument(name = "params") GQLSearchRequestInput searchInput,
             @GraphQLRootContext RequestContext context
             ) throws ServiceException {


### PR DESCRIPTION
…and more flag in response variable 'queryMore' added to response.

Summary:

Changed resolver response to be like SearchResponse.
- queryMore flag will be returned in the search response.
- searchType is not visible in request or returned results.

Docs:

Can be viewed with GraphiQL Document explorer

Testing:

Tested searching with the queries in the ticket.

Testing to be done by QA:

Test both updated queries with the sample query data on the ticket.
https://jira.corp.synacor.com/browse/ZCS-4167

Linked PR:

Zimbra/zm-mailbox#713