### PR TITLE
ZCS-4905 Implement Sessions list. Update authenticate zsc to forward request information.

### DIFF
--- a/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
@@ -1,0 +1,87 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.outputs;
+
+import com.zimbra.common.gql.GqlConstants;
+import com.zimbra.soap.account.type.AuthToken;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLSessionInfo class.<br>
+ * Contains session response information.
+ * @see com.zimbra.cs.session.Session
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.outputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name=GqlConstants.CLASS_SESSION_INFO, description="Session information")
+public class GQLSessionInfo {
+    protected AuthToken authToken;
+    protected Long createdDate;
+    protected Long lastAccessed;
+    protected String userAgent;
+    protected String requestIPAddress;
+
+    @GraphQLQuery(name=GqlConstants.AUTH_TOKEN, description="The session auth token")
+    public AuthToken getAuthToken() {
+        return authToken;
+    }
+
+    public void setAuthToken(AuthToken authToken) {
+        this.authToken = authToken;
+    }
+
+    @GraphQLQuery(name=GqlConstants.CREATED_DATE, description="The date of session creation")
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    @GraphQLQuery(name=GqlConstants.LAST_ACCESSED, description="The last time the session was accessed")
+    public Long getLastAccessed() {
+        return lastAccessed;
+    }
+
+    public void setLastAccessed(Long lastAccessed) {
+        this.lastAccessed = lastAccessed;
+    }
+
+    @GraphQLQuery(name=GqlConstants.USER_AGENT, description="The user-agent at session creation")
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
+    }
+
+    @GraphQLQuery(name=GqlConstants.REQUEST_IP_ADDRESS, description="The request IP at session creation")
+    public String getRequestIPAddress() {
+        return requestIPAddress;
+    }
+
+    public void setRequestIPAddress(String requestIPAddress) {
+        this.requestIPAddress = requestIPAddress;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
@@ -1,0 +1,116 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.cs.account.AuthTokenException;
+import com.zimbra.cs.session.Session;
+import com.zimbra.cs.session.SessionCache;
+import com.zimbra.cs.session.SoapSession;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.outputs.GQLSessionInfo;
+import com.zimbra.graphql.repositories.IRepository;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.account.type.AuthToken;
+
+/**
+ * The ZNativeAuthRepository class.<br>
+ * Contains direct Zimbra data access methods for auth.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.repositories.impl
+ * @copyright Copyright © 2018
+ */
+public class ZNativeAuthRepository extends ZXMLRepository implements IRepository {
+
+    /**
+     * Creates an instance.
+     */
+    public ZNativeAuthRepository() {
+        super();
+    }
+
+    /**
+     * Retrieves a list of sessions associated with the request account.<br>
+     * Sessions are retrieved from the acting server's SessionCache.
+     *
+     * @param rctxt The request context
+     * @return List of associated sessions
+     * @throws ServiceException If there are issues retrieving the session information
+     */
+    public List<GQLSessionInfo> sessions(RequestContext rctxt) throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final String accountId = zsc.getRequestedAccountId();
+        // get all sessions by account id
+        return SessionCache.getAllSessions(accountId)
+            .stream()
+            // filter out non-imap/soap types
+            .filter(p -> Session.Type.IMAP.equals(p.getSessionType())
+                      || Session.Type.SOAP.equals(p.getSessionType()))
+            // build session info list
+            .map(p -> toSessionInfo(p))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Builds a GQLSessionInfo response object from a Session.
+     *
+     * @param session The session data
+     * @return GQLSessionInfo response
+     */
+    protected GQLSessionInfo toSessionInfo(Session session) {
+        final GQLSessionInfo sessionInfo = new GQLSessionInfo();
+        sessionInfo.setAuthToken(getAuthToken(session));
+        sessionInfo.setCreatedDate(session.getCreationTime());
+        sessionInfo.setLastAccessed(session.getLastAccessTime());
+        sessionInfo.setUserAgent(session.getUserAgent());
+        sessionInfo.setRequestIPAddress(session.getRequestIPAddress());
+        return sessionInfo;
+    }
+
+    /**
+     * Retrieves auth token from session and converts to response token.
+     *
+     * @param session The session to retrieve auth token from
+     * @return Response AuthToken
+     */
+    protected AuthToken getAuthToken(Session session) {
+        AuthToken responseToken = null;
+        // fetch auth token if soap session
+        if (session != null && session instanceof SoapSession) {
+            try {
+                final com.zimbra.cs.account.AuthToken authToken = ((SoapSession)session).getAuthToken();
+                if (authToken != null) {
+                    responseToken = new AuthToken(authToken.getEncoded(), false);
+                    responseToken.setLifetime(authToken.getExpires());
+                }
+            } catch (final AuthTokenException e) {
+                ZimbraLog.extensions.error(
+                    "Unable to determine auth token associated with session id: %s.",
+                    session.getSessionId());
+                // don't fail all on missing authToken
+            }
+        }
+        return responseToken;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
@@ -40,7 +40,7 @@ import com.zimbra.soap.account.type.AuthToken;
  * @package com.zimbra.graphql.repositories.impl
  * @copyright Copyright © 2018
  */
-public class ZNativeAuthRepository extends ZXMLRepository implements IRepository {
+public class ZNativeAuthRepository extends ZRepository implements IRepository {
 
     /**
      * Creates an instance.

--- a/src/java/com/zimbra/graphql/repositories/impl/ZRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZRepository.java
@@ -16,18 +16,19 @@
  */
 package com.zimbra.graphql.repositories.impl;
 
+import com.zimbra.common.util.ZimbraLog;
+
 /**
- * The ZXMLRepository class.<br>
- * Will contain shared xml repository methods.
+ * The ZRepository class.
  *
  * @author Zimbra API Team
  * @package com.zimbra.graphql.repositories.impl
  * @copyright Copyright © 2018
  */
-public abstract class ZXMLRepository extends ZRepository {
+public abstract class ZRepository {
 
-    public  ZXMLRepository() {
-        super();
+    public  ZRepository() {
+        ZimbraLog.extensions.info("Loading %s . . .", this.getClass().getName());
     }
 
 }

--- a/src/java/com/zimbra/graphql/resolvers/impl/AuthResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AuthResolver.java
@@ -16,15 +16,20 @@
  */
 package com.zimbra.graphql.resolvers.impl;
 
+import java.util.List;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLAuthRequestInput;
+import com.zimbra.graphql.models.outputs.GQLSessionInfo;
+import com.zimbra.graphql.repositories.impl.ZNativeAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
 import com.zimbra.soap.account.message.AuthResponse;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 
 /**
@@ -37,22 +42,31 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  */
 public class AuthResolver {
 
-    protected ZXMLAuthRepository authRepository = null;
+    protected ZXMLAuthRepository xmlAuthRepository = null;
+    protected ZNativeAuthRepository nativeAuthRepository = null;
 
     /**
-     * Creates an instance with specified auth repository.
+     * Creates an instance with specified auth repositories.
      *
-     * @param authRepository The auth repository
+     * @param xmlAuthRepository The xml auth repository
+     * @param nativeAuthRepository The native auth repository
      */
-    public AuthResolver(ZXMLAuthRepository authRepository) {
-        this.authRepository = authRepository;
+    public AuthResolver(ZXMLAuthRepository xmlAuthRepository,
+        ZNativeAuthRepository nativeAuthRepository) {
+        this.xmlAuthRepository = xmlAuthRepository;
+        this.nativeAuthRepository = nativeAuthRepository;
     }
 
     @GraphQLMutation(description = "Authenticate for an account.")
     public AuthResponse authenticate(
         @GraphQLNonNull @GraphQLArgument(name = "authInput") GQLAuthRequestInput authRequestInput,
         @GraphQLRootContext RequestContext context) throws ServiceException {
-        return authRepository.authenticate(context, authRequestInput);
+        return xmlAuthRepository.authenticate(context, authRequestInput);
     }
 
+    @GraphQLQuery(description = "Lists all IMAP, and SOAP sessions for the requesting account.")
+    public List<GQLSessionInfo> sessions(
+        @GraphQLRootContext RequestContext context) throws ServiceException {
+        return nativeAuthRepository.sessions(context);
+    }
 }

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -35,6 +35,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.extension.ExtensionHttpHandler;
 import com.zimbra.graphql.errors.GQLError;
+import com.zimbra.graphql.repositories.impl.ZNativeAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
@@ -228,7 +229,7 @@ public class GQLServlet extends ExtensionHttpHandler {
      */
     protected GraphQLSchema buildSchema() {
         final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
-        final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository());
+        final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository(), new ZNativeAuthRepository());
         final ContactResolver contactResolver = new ContactResolver(new ZXMLContactRepository());
         final FolderResolver folderResolver = new FolderResolver(new ZXMLFolderRepository());
         final MessageResolver messageResolver = new MessageResolver(new ZXMLMessageRepository());

--- a/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
@@ -52,7 +52,7 @@ public class XMLDocumentUtilities {
         throws ServiceException {
         final Map<String, Object> context = new HashMap<String, Object>();
         context.put(SoapEngine.ZIMBRA_CONTEXT,
-            GQLAuthUtilities.getGuestZimbraSoapContext(request.getQName(), handler));
+            GQLAuthUtilities.getGuestZimbraSoapContext(request.getQName(), handler, rctxt));
         context.put(SoapServlet.SERVLET_REQUEST, rctxt.getRawRequest());
         context.put(SoapServlet.SERVLET_RESPONSE, rctxt.getRawResponse());
         return handler.handle(request, context);


### PR DESCRIPTION
* Implement support for session list from `SessionCache` for the requesting user.
  * Using native repository for later encapsulation when refactoring the `buildSchema` method. Will likely need to add more work eventually if we're to release only specific APIs.
* Updated zm-gql authenticate to forward request headers (ip, user-agent, and enable session tracking).

Requires Zimbra/zm-mailbox#739 to be cherry-pick'd onto [Zimbra/zm-mailbox:feature/graphql](https://github.com/Zimbra/zm-mailbox/tree/feature/graphql). Alternatively, use [Zimbra/zm-mailbox:ZCS-4905](https://github.com/Zimbra/zm-mailbox/tree/ZCS-4905) which has this.

**Testing Done**
See jira ticket for query. Authenticated via webclient, gql, soap call with empty session block to enable tracking - then viewed listings.

**Testing to be done by QA**
Create sessions and fetch with the query.