### PR TITLE
ZCS-4905 Don't return auth token in sessions list.

### DIFF
--- a/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
@@ -33,6 +33,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
 @GraphQLType(name=GqlConstants.CLASS_SESSION_INFO, description="Session information")
 public class GQLSessionInfo {
     protected String sessionId;
+    protected String browserInfo;
     protected Long createdDate;
     protected Long lastAccessed;
     protected String userAgent;
@@ -45,6 +46,15 @@ public class GQLSessionInfo {
 
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
+    }
+
+    @GraphQLQuery(name=GqlConstants.BROWSER_INFO, description="The browser information at session creation")
+    public String getBrowserInfo() {
+        return browserInfo;
+    }
+
+    public void setBrowserInfo(String browserInfo) {
+        this.browserInfo = browserInfo;
     }
 
     @GraphQLQuery(name=GqlConstants.CREATED_DATE, description="The date of session creation")

--- a/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
@@ -32,10 +32,20 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  */
 @GraphQLType(name=GqlConstants.CLASS_SESSION_INFO, description="Session information")
 public class GQLSessionInfo {
+    protected String sessionId;
     protected Long createdDate;
     protected Long lastAccessed;
     protected String userAgent;
     protected String requestIPAddress;
+
+    @GraphQLQuery(name=GqlConstants.SESSION_ID, description="The session id")
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
 
     @GraphQLQuery(name=GqlConstants.CREATED_DATE, description="The date of session creation")
     public Long getCreatedDate() {

--- a/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLSessionInfo.java
@@ -17,7 +17,6 @@
 package com.zimbra.graphql.models.outputs;
 
 import com.zimbra.common.gql.GqlConstants;
-import com.zimbra.soap.account.type.AuthToken;
 
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.types.GraphQLType;
@@ -33,20 +32,10 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  */
 @GraphQLType(name=GqlConstants.CLASS_SESSION_INFO, description="Session information")
 public class GQLSessionInfo {
-    protected AuthToken authToken;
     protected Long createdDate;
     protected Long lastAccessed;
     protected String userAgent;
     protected String requestIPAddress;
-
-    @GraphQLQuery(name=GqlConstants.AUTH_TOKEN, description="The session auth token")
-    public AuthToken getAuthToken() {
-        return authToken;
-    }
-
-    public void setAuthToken(AuthToken authToken) {
-        this.authToken = authToken;
-    }
 
     @GraphQLQuery(name=GqlConstants.CREATED_DATE, description="The date of session creation")
     public Long getCreatedDate() {

--- a/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
@@ -20,17 +20,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.zimbra.common.service.ServiceException;
-import com.zimbra.common.util.ZimbraLog;
-import com.zimbra.cs.account.AuthTokenException;
 import com.zimbra.cs.session.Session;
 import com.zimbra.cs.session.SessionCache;
-import com.zimbra.cs.session.SoapSession;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.outputs.GQLSessionInfo;
 import com.zimbra.graphql.repositories.IRepository;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
 import com.zimbra.soap.ZimbraSoapContext;
-import com.zimbra.soap.account.type.AuthToken;
 
 /**
  * The ZNativeAuthRepository class.<br>
@@ -79,38 +75,11 @@ public class ZNativeAuthRepository extends ZRepository implements IRepository {
      */
     protected GQLSessionInfo toSessionInfo(Session session) {
         final GQLSessionInfo sessionInfo = new GQLSessionInfo();
-        sessionInfo.setAuthToken(getAuthToken(session));
         sessionInfo.setCreatedDate(session.getCreationTime());
         sessionInfo.setLastAccessed(session.getLastAccessTime());
         sessionInfo.setUserAgent(session.getUserAgent());
         sessionInfo.setRequestIPAddress(session.getRequestIPAddress());
         return sessionInfo;
-    }
-
-    /**
-     * Retrieves auth token from session and converts to response token.
-     *
-     * @param session The session to retrieve auth token from
-     * @return Response AuthToken
-     */
-    protected AuthToken getAuthToken(Session session) {
-        AuthToken responseToken = null;
-        // fetch auth token if soap session
-        if (session != null && session instanceof SoapSession) {
-            try {
-                final com.zimbra.cs.account.AuthToken authToken = ((SoapSession)session).getAuthToken();
-                if (authToken != null) {
-                    responseToken = new AuthToken(authToken.getEncoded(), false);
-                    responseToken.setLifetime(authToken.getExpires());
-                }
-            } catch (final AuthTokenException e) {
-                ZimbraLog.extensions.error(
-                    "Unable to determine auth token associated with session id: %s.",
-                    session.getSessionId());
-                // don't fail all on missing authToken
-            }
-        }
-        return responseToken;
     }
 
 }

--- a/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.cs.session.Session;
 import com.zimbra.cs.session.SessionCache;
+import com.zimbra.cs.session.SoapSession;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.outputs.GQLSessionInfo;
 import com.zimbra.graphql.repositories.IRepository;
@@ -80,6 +81,9 @@ public class ZNativeAuthRepository extends ZRepository implements IRepository {
         sessionInfo.setLastAccessed(session.getLastAccessTime());
         sessionInfo.setUserAgent(session.getUserAgent());
         sessionInfo.setRequestIPAddress(session.getRequestIPAddress());
+        if (session instanceof SoapSession) {
+            sessionInfo.setBrowserInfo(((SoapSession)session).getOriginalUserAgent());
+        }
         return sessionInfo;
     }
 

--- a/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZNativeAuthRepository.java
@@ -75,6 +75,7 @@ public class ZNativeAuthRepository extends ZRepository implements IRepository {
      */
     protected GQLSessionInfo toSessionInfo(Session session) {
         final GQLSessionInfo sessionInfo = new GQLSessionInfo();
+        sessionInfo.setSessionId(session.getSessionId());
         sessionInfo.setCreatedDate(session.getCreationTime());
         sessionInfo.setLastAccessed(session.getLastAccessTime());
         sessionInfo.setUserAgent(session.getUserAgent());


### PR DESCRIPTION
As requested, removing auth token from sessions list response.

Requires branch [Zimbra/zm-mailbox:ZCS-4905](https://github.com/Zimbra/zm-mailbox/tree/ZCS-4905)

See associated PRs:
Zimbra/zm-mailbox#753
Zimbra/zm-taglib#16

**Testing done**
See jira ticket.

**Testing to be done by QA**
Verify auth token is no longer in response.