### PR TITLE
ZCS-4583 Implement GetInfoRequest in the AccountInfoRepository class

### DIFF
--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -24,6 +24,7 @@ import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLPrefInput;
 import com.zimbra.graphql.models.outputs.AccountInfo;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
+import com.zimbra.soap.account.message.GetInfoResponse;
 import com.zimbra.soap.account.type.Pref;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
@@ -57,6 +58,23 @@ public class AccountResolver {
     public AccountInfo accountInfoGet(@GraphQLRootContext RequestContext context)
         throws ServiceException {
         return accountRepository.accountInfoGet(context);
+    }
+
+    /**
+     * @param context
+     * @param sections
+     * @param rights
+     * @return GetInfoResponse
+     * @throws ServiceException
+     */
+    @GraphQLQuery(description="Retrieve info")
+    public GetInfoResponse info(@GraphQLRootContext RequestContext context,
+            @GraphQLArgument(name=GqlConstants.SECTIONS,
+                description="Comma separated list of sections to return information about") String sections,
+            @GraphQLArgument(name=GqlConstants.RIGHTS,
+                description="Comma separated list of rights to return information about") String rights)
+        throws ServiceException {
+        return accountRepository.info(context, sections, rights);
     }
 
     @GraphQLMutation(description="Logout/end session for current user")

--- a/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
+import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.soap.DocumentHandler;
 import com.zimbra.soap.JaxbUtil;
@@ -80,7 +81,11 @@ public class XMLDocumentUtilities {
      * @see JaxbUtil#jaxbToElement(Object)
      */
     public static Element toElement(Object o) throws ServiceException {
-        return JaxbUtil.jaxbToElement(o);
+        Element element = JaxbUtil.jaxbToElement(o);
+        if (element != null) {
+            ZimbraLog.gql.debug("\n" + element.prettyPrint());
+        }
+        return element;
     }
 
     /**
@@ -89,6 +94,9 @@ public class XMLDocumentUtilities {
      * @see JaxbUtil#elementToJaxb(Element, Class)
      */
     public static <T> T fromElement(Element e, Class<?> klass) throws ServiceException {
+        if (e != null) {
+            ZimbraLog.gql.debug("\n" + e.prettyPrint());
+        }
         return JaxbUtil.elementToJaxb(e, klass);
     }
 


### PR DESCRIPTION
**Problem:** implement GetInfoRequest in gql

**Fix:** Implemented GetInfoRequest in gql as "infoGet"

**Testing done:**
- Tested infoGet from GraphiQL manually with some of the options manually.

**Testing needs to be done by QA:**
- Test infoGet completely in comparison with soap GetInfoRequest.

**Linked PR:**
https://github.com/Zimbra/zm-mailbox/pull/785
