### PR TITLE
ZCS-6135 GraphQL support for ChangePassword

### DIFF
--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
@@ -179,11 +179,14 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
      * @param clearCookies Denotes whether to clear cookies for the requester
      * @throws ServiceException If there are issues executing the document
      */
-    public void accountEndSession(RequestContext rctxt, String sessionId, Boolean clearCookies) throws ServiceException {
+    public void accountEndSession(RequestContext rctxt, String sessionId, Boolean clearCookies,
+        Boolean clearAllSoapSessions, Boolean excludeCurrentSession) throws ServiceException {
         final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
         final EndSessionRequest request = new EndSessionRequest();
         request.setSessionId(sessionId);
         request.setLogOff(clearCookies);
+        request.setClearAllSoapSessions(clearAllSoapSessions);
+        request.setExcludeCurrentSession(excludeCurrentSession);
         final Element response = XMLDocumentUtilities.executeDocument(
                 endSessionHandler,
                 zsc,

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
@@ -46,6 +46,7 @@ import com.zimbra.soap.account.message.GetInfoResponse;
 import com.zimbra.soap.account.message.GetPrefsRequest;
 import com.zimbra.soap.account.message.GetPrefsResponse;
 import com.zimbra.soap.account.message.ModifyPrefsRequest;
+import com.zimbra.soap.account.type.AuthToken;
 import com.zimbra.soap.account.type.Pref;
 import com.zimbra.soap.type.AccountBy;
 import com.zimbra.soap.type.AccountSelector;
@@ -106,6 +107,7 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
      * @param prefsHandler The prefs handler
      * @param modifyPrefsHandler The pref mutation handler
      * @param infoHandler Handler for GetInfo
+     * @param changePasswordHandler Handler for change password
      */
     public ZXMLAccountRepository(GetAccountInfo accountInfoHandler, EndSession endSessionHandler,
         GetPrefs prefsHandler, ModifyPrefs modifyPrefsHandler, GetInfo infoHandler, ChangePassword changePasswordHandler) {
@@ -139,7 +141,8 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
         final Element response = XMLDocumentUtilities.executeDocument(
                 infoHandler,
                 zsc,
-                XMLDocumentUtilities.toElement(request));
+                XMLDocumentUtilities.toElement(request),
+                rctxt);
         GetInfoResponse resp = null;
         if (response != null) {
             resp = XMLDocumentUtilities.fromElement(response,
@@ -164,7 +167,8 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
         final Element response = XMLDocumentUtilities.executeDocument(
                 accountInfoHandler,
                 zsc,
-                XMLDocumentUtilities.toElement(request));
+                XMLDocumentUtilities.toElement(request),
+                rctxt);
         if (response != null) {
             final GetAccountInfoResponse resp = XMLDocumentUtilities.fromElement(response,
                 GetAccountInfoResponse.class);
@@ -199,7 +203,8 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
         final Element response = XMLDocumentUtilities.executeDocument(
                 endSessionHandler,
                 zsc,
-                XMLDocumentUtilities.toElement(request));
+                XMLDocumentUtilities.toElement(request),
+                rctxt);
         if (response == null) {
             throw ServiceException.FAILURE("EndSessionRequest failed", null);
         }
@@ -220,7 +225,8 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
         final Element response = XMLDocumentUtilities.executeDocument(
             prefsHandler,
             zsc,
-            XMLDocumentUtilities.toElement(request));
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
         List<Pref> responsePrefs = null;
         if (response != null) {
             final GetPrefsResponse prefsResponse = XMLDocumentUtilities.fromElement(response, GetPrefsResponse.class);
@@ -249,7 +255,8 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
         final Element response = XMLDocumentUtilities.executeDocument(
             modifyPrefsHandler,
             zsc,
-            XMLDocumentUtilities.toElement(request));
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
         List<Pref> responsePrefs = request.getPrefs();
         if (response != null && !request.getPrefs().isEmpty()) {
             responsePrefs  = this.prefs(rctxt, responsePrefs);
@@ -259,24 +266,28 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
 
 
     /**
-     *
+     * 
      * @param acctSelector The account for which password is changed
      * @param oldPassword old Password
-     * @param newPassword new password
+     * @param newPassword  new password
+     * @param virtualHost  virtualHost
      * @param rctxt The request context
+     * @return Change password response
      * @throws ServiceException If there are issues executing the document
      */
-    public ChangePasswordResponse changePassword(AccountSelector acctSelector, String oldPassword, String newPassword, RequestContext rctxt) throws ServiceException {
+    public ChangePasswordResponse changePassword(AccountSelector acctSelector, String oldPassword, 
+        String newPassword, String virtualHost, RequestContext rctxt) throws ServiceException {
         final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
         final ChangePasswordRequest request = new ChangePasswordRequest();
         request.setOldPassword(oldPassword);
         request.setPassword(newPassword);
         request.setAccount(acctSelector);
+        request.setVirtualHost(virtualHost);
         final Element response = XMLDocumentUtilities.executeDocument(
                 changePasswordHandler,
                 zsc,
-                rctxt,
-                XMLDocumentUtilities.toElement(request));
+                XMLDocumentUtilities.toElement(request),
+                rctxt);
         if (response == null) {
             throw ServiceException.FAILURE("ChangePasswordRequest failed", null);
         }

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLContactRepository.java
@@ -125,7 +125,8 @@ public class ZXMLContactRepository extends ZXMLItemRepository implements IReposi
         final Element response = XMLDocumentUtilities.executeDocument(
             getContactHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         if (response != null) {
             final GetContactsResponse contactsResponse = XMLDocumentUtilities.fromElement(
                 response,
@@ -160,7 +161,8 @@ public class ZXMLContactRepository extends ZXMLItemRepository implements IReposi
         final Element response = XMLDocumentUtilities.executeDocument(
             createContactHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         ContactInfo zCreatedContact = null;
         if (response != null) {
             zCreatedContact = XMLDocumentUtilities
@@ -240,7 +242,8 @@ public class ZXMLContactRepository extends ZXMLItemRepository implements IReposi
         final Element response = XMLDocumentUtilities.executeDocument(
             modifyContactHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         ContactInfo result = null;
         if (response != null) {
             result = XMLDocumentUtilities.fromElement(response.getElement(MailConstants.E_CONTACT),

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLFolderRepository.java
@@ -145,7 +145,8 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
         final Element response = XMLDocumentUtilities.executeDocument(
             getFolderHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         Folder folder = null;
         if (response != null) {
             folder = XMLDocumentUtilities.fromElement(response.getElement(MailConstants.E_FOLDER),
@@ -171,7 +172,8 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
         final Element response = XMLDocumentUtilities.executeDocument(
             createFolderHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         Folder zCreatedFolder = null;
         if (response != null) {
             zCreatedFolder = XMLDocumentUtilities
@@ -216,7 +218,8 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
         final Element response = XMLDocumentUtilities.executeDocument(
             getSearchFolderHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         final List<SearchFolder> searchFolders = new ArrayList<SearchFolder>();
         if (response != null && response.hasChildren()) {
             final List<Element> searches = response.listElements(MailConstants.E_SEARCH);
@@ -245,7 +248,8 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
         final Element response = XMLDocumentUtilities.executeDocument(
             createSearchFolderHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         SearchFolder zCreatedSearchFolder = null;
         if (response != null) {
             zCreatedSearchFolder = XMLDocumentUtilities.fromElement(response.getElement(MailConstants.E_SEARCH),
@@ -271,7 +275,8 @@ public class ZXMLFolderRepository extends ZXMLItemRepository implements IReposit
         final Element response = XMLDocumentUtilities.executeDocument(
             modifySearchFolderHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         SearchFolder modifiedSearchFolder = null;
         if (response != null) {
             modifiedSearchFolder = XMLDocumentUtilities.fromElement(response.getElement(MailConstants.E_SEARCH),

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLItemRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLItemRepository.java
@@ -66,7 +66,8 @@ public class ZXMLItemRepository extends ZXMLRepository implements IRepository {
         final Element response = XMLDocumentUtilities.executeDocument(
             actionHandler,
             GQLAuthUtilities.getZimbraSoapContext(rctxt),
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         return response;
     }
 
@@ -85,7 +86,8 @@ public class ZXMLItemRepository extends ZXMLRepository implements IRepository {
         final Element response = XMLDocumentUtilities.executeDocument(
             actionHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         // return operation results
         ActionResult result = null;
         if (response != null) {

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLMessageRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLMessageRepository.java
@@ -93,7 +93,8 @@ public class ZXMLMessageRepository extends ZXMLItemRepository implements IReposi
         final Element response = XMLDocumentUtilities.executeDocument(
             getMessageHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         Msg message = null;
         if (response != null) {
             message = XMLDocumentUtilities
@@ -132,7 +133,8 @@ public class ZXMLMessageRepository extends ZXMLItemRepository implements IReposi
         final Element response = XMLDocumentUtilities.executeDocument(
             sendMessageHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         MsgWithGroupInfo message = null;
         if (response != null) {
             message = XMLDocumentUtilities

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLSearchRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLSearchRepository.java
@@ -155,7 +155,8 @@ public class ZXMLSearchRepository extends ZXMLRepository implements IRepository 
         final Element response = XMLDocumentUtilities.executeDocument(
             searchHandler,
             zsc,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         return XMLDocumentUtilities.fromElement(response, SearchResponse.class);
     }
 

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -86,7 +86,7 @@ public class AccountResolver {
         @GraphQLArgument(name=GqlConstants.CLEAR_ALL_SOAP_SESSIONS, description="Denotes whether to clear all soap sessions", defaultValue="false") boolean clearAllSoapSessions,
         @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to retain current session, when clear all session is true", defaultValue="false") boolean excludeCurrentSession,
         @GraphQLRootContext RequestContext context) throws ServiceException {
-        accountRepository.accountEndSession(context, sessionId, clearCookies);
+        accountRepository.accountEndSession(context, sessionId, clearCookies, clearAllSoapSessions, excludeCurrentSession);
     }
 
     @GraphQLQuery(description="Retrieves prefs by given properties")

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -81,6 +81,8 @@ public class AccountResolver {
     public void accountEndSession(
         @GraphQLArgument(name=GqlConstants.SESSION_ID, description="The id of a specific session to end") String sessionId,
         @GraphQLArgument(name=GqlConstants.CLEAR_COOKIES, description="Denotes whether to clear cookies", defaultValue="false") boolean clearCookies,
+        @GraphQLArgument(name=GqlConstants.CLEAR_ALL_SOAP_SESSIONS, description="Denotes whether to clear all soap sessions", defaultValue="false") boolean clearAllSoapSessions,
+        @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to retain current session, when clear all session is true", defaultValue="false") boolean excludeCurrentSession,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         accountRepository.accountEndSession(context, sessionId, clearCookies);
     }

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -24,8 +24,10 @@ import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLPrefInput;
 import com.zimbra.graphql.models.outputs.AccountInfo;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
+import com.zimbra.soap.account.message.ChangePasswordResponse;
 import com.zimbra.soap.account.message.GetInfoResponse;
 import com.zimbra.soap.account.type.Pref;
+import com.zimbra.soap.type.AccountSelector;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLMutation;
@@ -98,4 +100,19 @@ public class AccountResolver {
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return accountRepository.prefsModify(context, prefs);
     }
+
+    @GraphQLMutation(description="Change password.")
+    public ChangePasswordResponse passwordChange(
+        @GraphQLArgument(name = GqlConstants.ACCOUNT_SELECTOR, description =
+            "Denotes the account for which password is to be changed.") AccountSelector accountInput,
+        @GraphQLNonNull @GraphQLArgument(name = GqlConstants.OLD_PASSWORD,
+            description = "The old password for this account).") String password,
+        @GraphQLNonNull @GraphQLArgument(name = GqlConstants.NEW_PASSWORD,
+            description = "The new password for this account.") String oldPassword,
+        @GraphQLArgument(name = GqlConstants.VIRTUAL_HOST,
+        description = "The virtual host to indicae domain for the account.") String virtualHost,
+        @GraphQLNonNull @GraphQLRootContext RequestContext context) throws ServiceException {
+        return accountRepository.changePassword(accountInput, password, oldPassword, virtualHost, context);
+    }
 }
+

--- a/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
@@ -19,6 +19,8 @@ package com.zimbra.graphql.utilities;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.common.util.ZimbraLog;
@@ -72,6 +74,26 @@ public class XMLDocumentUtilities {
         throws ServiceException {
         final Map<String, Object> context = new HashMap<String, Object>();
         context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+        return handler.handle(request, context);
+    }
+
+    /**
+     * Executes a given request on a document handler.
+     *
+     * @param handler The handler to handle the request
+     * @param zsc The zimbra soap context for the request
+     * @param rctxt The request context
+     * @param request The request to execute
+     * @return The document response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public static Element executeDocument(DocumentHandler handler, ZimbraSoapContext zsc,
+        RequestContext rctxt, Element request)
+        throws ServiceException {
+        final Map<String, Object> context = new HashMap<String, Object>();
+        final HttpServletRequest req = rctxt.getRawRequest();
+        context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+        context.put(SoapServlet.SERVLET_REQUEST, req);
         return handler.handle(request, context);
     }
 

--- a/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
@@ -67,32 +67,15 @@ public class XMLDocumentUtilities {
      * @param handler The handler to handle the request
      * @param zsc The zimbra soap context for the request
      * @param request The request to execute
-     * @return The document response
-     * @throws ServiceException If there are issues executing the document
-     */
-    public static Element executeDocument(DocumentHandler handler, ZimbraSoapContext zsc, Element request)
-        throws ServiceException {
-        final Map<String, Object> context = new HashMap<String, Object>();
-        context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
-        return handler.handle(request, context);
-    }
-
-    /**
-     * Executes a given request on a document handler.
-     *
-     * @param handler The handler to handle the request
-     * @param zsc The zimbra soap context for the request
      * @param rctxt The request context
-     * @param request The request to execute
      * @return The document response
      * @throws ServiceException If there are issues executing the document
      */
-    public static Element executeDocument(DocumentHandler handler, ZimbraSoapContext zsc,
-        RequestContext rctxt, Element request)
+    public static Element executeDocument(DocumentHandler handler, ZimbraSoapContext zsc, Element request, RequestContext rctxt)
         throws ServiceException {
         final Map<String, Object> context = new HashMap<String, Object>();
-        final HttpServletRequest req = rctxt.getRawRequest();
         context.put(SoapEngine.ZIMBRA_CONTEXT, zsc);
+        final HttpServletRequest req = rctxt.getRawRequest();
         context.put(SoapServlet.SERVLET_REQUEST, req);
         return handler.handle(request, context);
     }


### PR DESCRIPTION
Implemented changePassword API in GraphQL.

Tested scenarios with invalid old and new password, not providing required attributes.

mutation test {
  changePassword (oldPassword: "test123", 
    newPassword: "test456", accountSelector: {
      accountBy:name,
      key: "user1@example.com"
    })
  {
    authToken
    lifetime
  }
}


