### PR TITLE
ZCS-6063 Adding  new params for endSession

### DIFF
--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
@@ -179,11 +179,14 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
      * @param clearCookies Denotes whether to clear cookies for the requester
      * @throws ServiceException If there are issues executing the document
      */
-    public void accountEndSession(RequestContext rctxt, String sessionId, Boolean clearCookies) throws ServiceException {
+    public void accountEndSession(RequestContext rctxt, String sessionId, Boolean clearCookies,
+        Boolean clearAllSoapSessions, Boolean excludeCurrentSession) throws ServiceException {
         final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
         final EndSessionRequest request = new EndSessionRequest();
         request.setSessionId(sessionId);
         request.setLogOff(clearCookies);
+        request.setClearAllSoapSessions(clearAllSoapSessions);
+        request.setExcludeCurrentSession(excludeCurrentSession);
         final Element response = XMLDocumentUtilities.executeDocument(
                 endSessionHandler,
                 zsc,

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -81,6 +81,8 @@ public class AccountResolver {
     public void accountEndSession(
         @GraphQLArgument(name=GqlConstants.SESSION_ID, description="The id of a specific session to end") String sessionId,
         @GraphQLArgument(name=GqlConstants.CLEAR_COOKIES, description="Denotes whether to clear cookies", defaultValue="false") boolean clearCookies,
+        @GraphQLArgument(name=GqlConstants.CLEAR_ALL_SOAP_SESSIONS, description="Denotes whether to clear all soap sessions", defaultValue="false") boolean clearAllSoapSessions,
+        @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to clear cookies", defaultValue="false") boolean excludeCurrentSession,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         accountRepository.accountEndSession(context, sessionId, clearCookies);
     }

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -82,7 +82,7 @@ public class AccountResolver {
         @GraphQLArgument(name=GqlConstants.SESSION_ID, description="The id of a specific session to end") String sessionId,
         @GraphQLArgument(name=GqlConstants.CLEAR_COOKIES, description="Denotes whether to clear cookies", defaultValue="false") boolean clearCookies,
         @GraphQLArgument(name=GqlConstants.CLEAR_ALL_SOAP_SESSIONS, description="Denotes whether to clear all soap sessions", defaultValue="false") boolean clearAllSoapSessions,
-        @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to clear current session", defaultValue="false") boolean excludeCurrentSession,
+        @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to retain current session, when clear all session is true", defaultValue="false") boolean excludeCurrentSession,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         accountRepository.accountEndSession(context, sessionId, clearCookies);
     }

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -82,7 +82,7 @@ public class AccountResolver {
         @GraphQLArgument(name=GqlConstants.SESSION_ID, description="The id of a specific session to end") String sessionId,
         @GraphQLArgument(name=GqlConstants.CLEAR_COOKIES, description="Denotes whether to clear cookies", defaultValue="false") boolean clearCookies,
         @GraphQLArgument(name=GqlConstants.CLEAR_ALL_SOAP_SESSIONS, description="Denotes whether to clear all soap sessions", defaultValue="false") boolean clearAllSoapSessions,
-        @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to clear cookies", defaultValue="false") boolean excludeCurrentSession,
+        @GraphQLArgument(name=GqlConstants.EXCLUDE_CURRENT_SESSION, description="Denotes whether to clear current session", defaultValue="false") boolean excludeCurrentSession,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         accountRepository.accountEndSession(context, sessionId, clearCookies);
     }


### PR DESCRIPTION
Added support for 2 new params in endSession
clearAllSoapSessions
excludeCurrentSession

Tested the new attributes work in the GQL query