### PR TITLE
ZCS-6282 Base unit tests and method signature sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Afterwards, become the `zimbra` user and perform a `zmmailboxdctl restart`.
 
 ---
 
+## Testing
+
+**Unit testing the extension from CLI**
+
+```sh
+ant clean test
+```
+
+---
+
 ## Usage
 
 **API**

--- a/ivy.xml
+++ b/ivy.xml
@@ -38,6 +38,7 @@
       <dependency org="log4j" name="log4j" rev="1.2.16" />
       <dependency org="dom4j" name="dom4j" rev="1.5.2" />
       <dependency org="org.json" name="json" rev="20090211" />
+      <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.3.5.v20151012"/>
       <!-- jackson jars -->
       <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
       <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAccountRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAccountRepositoryTest.java
@@ -1,0 +1,493 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import java.util.Collections;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.service.account.ChangePassword;
+import com.zimbra.cs.service.account.CreateSignature;
+import com.zimbra.cs.service.account.DeleteSignature;
+import com.zimbra.cs.service.account.EndSession;
+import com.zimbra.cs.service.account.GetAccountInfo;
+import com.zimbra.cs.service.account.GetInfo;
+import com.zimbra.cs.service.account.GetPrefs;
+import com.zimbra.cs.service.account.GetSignatures;
+import com.zimbra.cs.service.account.GetWhiteBlackList;
+import com.zimbra.cs.service.account.ModifyPrefs;
+import com.zimbra.cs.service.account.ModifySignature;
+import com.zimbra.cs.service.account.ModifyWhiteBlackList;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.account.message.CreateSignatureResponse;
+import com.zimbra.soap.account.type.NameId;
+import com.zimbra.soap.account.type.Signature;
+
+
+/**
+ * Test class for {@link ZXMLAccountRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLAccountRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class, "executeDocument", "fromElement", "toElement");
+    }
+
+
+    /**
+     * Test method for {@link ZXMLAccountRepository#info}<br>
+     * Validates that the info request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testInfo() throws Exception {
+        final ZXMLAccountRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "info");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the info document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(GetInfo.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.info(rctxt, "", "");
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+    * Test method for {@link ZXMLAccountRepository#accountInfoGet}<br>
+    * Validates that the accountInfo request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testAccountInfoGet() throws Exception {
+       final String accountId = "account-id";
+       final AuthToken mockToken = EasyMock.createMock(AuthToken.class);
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "accountInfoGet");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to get an accountId from the zsc's token
+       expect(mockZsc.getAuthToken()).andReturn(mockToken);
+       expect(mockToken.getAccountId()).andReturn(accountId);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the GetAccountInfo document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(GetAccountInfo.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(null);
+
+       replay(mockZsc);
+       replay(mockToken);
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.accountInfoGet(rctxt);
+
+       verify(mockZsc);
+       verify(mockToken);
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#accountEndSession}<br>
+    * Validates that the endSession request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testAccountEndSession() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "accountEndSession");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the EndSession document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(EndSession.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(EasyMock.createMock(Element.class));
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.accountEndSession(rctxt, "session-id", true, true, false);
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#prefs}<br>
+    * Validates that the prefs request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testPrefs() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "prefs");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the GetPrefs document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(GetPrefs.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.prefs(rctxt, Collections.emptyList());
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#prefsModify}<br>
+    * Validates that the modify prefs request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testPrefsModify() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "prefsModify");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the ModifyPrefs document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(ModifyPrefs.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.prefsModify(rctxt, Collections.emptyList());
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#changePassword}<br>
+    * Validates that the change password request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testChangePassword() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "changePassword");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the ChangePassword document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(ChangePassword.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(mockResponse);
+       // expect to marshall a response
+       XMLDocumentUtilities.fromElement(eq(mockResponse), anyObject());
+       PowerMock.expectLastCall().andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.changePassword(null, "old-pass", "new-pass", "vhost", rctxt);
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#whiteBlackList}<br>
+    * Validates that the white black list request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testWhiteBlackList() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "whiteBlackList");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the GetWhiteBlackList document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(GetWhiteBlackList.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.whiteBlackList(rctxt);
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#whiteBlackListModify}<br>
+    * Validates that the modify white black list request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testWhiteBlackListModify() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "whiteBlackListModify");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the ModifyWhiteBlackList document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(ModifyWhiteBlackList.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.whiteBlackListModify(rctxt, Collections.emptyList(), Collections.emptyList());
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#signatures}<br>
+    * Validates that the signatures request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testSignatures() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "signatures");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the GetSignatures document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(GetSignatures.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(mockResponse);
+       // expect to marshall a response
+       XMLDocumentUtilities.fromElement(eq(mockResponse), anyObject());
+       PowerMock.expectLastCall().andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.signatures(rctxt);
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#signatureCreate}<br>
+    * Validates that the create signature request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testSignatureCreate() throws Exception {
+       final CreateSignatureResponse mockSigResponse = EasyMock.createMock(CreateSignatureResponse.class);
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "signatureCreate");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the CreateSignature document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(CreateSignature.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(mockResponse);
+       // expect to marshall a response
+       XMLDocumentUtilities.fromElement(eq(mockResponse), anyObject());
+       PowerMock.expectLastCall().andReturn(mockSigResponse);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.signatureCreate(rctxt, null);
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#signatureModify}<br>
+    * Validates that the modify signature request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testSignatureModify() throws Exception {
+       final Signature mockSignature = EasyMock.createMock(Signature.class);
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "signatureModify");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the ModifySignature document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(ModifySignature.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(mockResponse);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.signatureModify(rctxt, "sig-id", mockSignature);
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#signatureDelete}<br>
+    * Validates that the delete signature request is executed.
+    *
+    * @throws Exception If there are issues testing
+    */
+   @Test
+   public void testSignatureDelete() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "signatureDelete");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the DeleteSignature document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(DeleteSignature.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(mockResponse);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.signatureDelete(rctxt, new NameId(null, "sig-id"));
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+}

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAccountRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAccountRepositoryTest.java
@@ -291,7 +291,7 @@ public class ZXMLAccountRepositoryTest {
        PowerMock.replay(GQLAuthUtilities.class);
        PowerMock.replay(XMLDocumentUtilities.class);
 
-       repository.changePassword(null, "old-pass", "new-pass", "vhost", rctxt);
+       repository.changePassword(rctxt, null, "old-pass", "new-pass", "vhost");
 
        PowerMock.verify(GQLAuthUtilities.class);
        PowerMock.verify(XMLDocumentUtilities.class);

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAuthRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAuthRepositoryTest.java
@@ -1,0 +1,113 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.account.Auth;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.inputs.GQLAuthRequestInput;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link ZXMLAuthRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLAuthRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class,
+            "executeDocument", "executeDocumentAsGuest", "fromElement", "toElement");
+    }
+
+
+    /**
+     * Test method for {@link ZXMLAuthRepository#authenticate}<br>
+     * Validates that the authenticate request is executed as a guest with no zsc.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAuthenticate() throws Exception {
+        final ZXMLAuthRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLAuthRepository.class, "authenticate");
+
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the Auth document handler as a guest
+        expect(XMLDocumentUtilities
+                .executeDocumentAsGuest(anyObject(Auth.class), eq(rctxt), eq(mockRequest)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.authenticate(rctxt, new GQLAuthRequestInput());
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+}

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAuthRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAuthRepositoryTest.java
@@ -98,7 +98,7 @@ public class ZXMLAuthRepositoryTest {
         PowerMock.expectLastCall().andReturn(mockRequest);
         // expect to execute an element on the Auth document handler as a guest
         expect(XMLDocumentUtilities
-                .executeDocumentAsGuest(anyObject(Auth.class), eq(rctxt), eq(mockRequest)))
+                .executeDocumentAsGuest(anyObject(Auth.class), eq(mockRequest), eq(rctxt)))
             .andReturn(null);
 
         PowerMock.replay(GQLAuthUtilities.class);

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLContactRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLContactRepositoryTest.java
@@ -1,0 +1,209 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.mail.ContactAction;
+import com.zimbra.cs.service.mail.CreateContact;
+import com.zimbra.cs.service.mail.GetContacts;
+import com.zimbra.cs.service.mail.ModifyContact;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link ZXMLContactRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLContactRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class, "executeDocument", "fromElement", "toElement");
+    }
+
+
+    /**
+     * Test method for {@link ZXMLContactRepository#contacts}<br>
+     * Validates that the contacts request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testContacts() throws Exception {
+        final ZXMLContactRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLContactRepository.class, "contacts");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the GetContacts document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(GetContacts.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.contacts(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLContactRepository#contactCreate}<br>
+     * Validates that the create contact request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testContactCreate() throws Exception {
+        final ZXMLContactRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLContactRepository.class, "contactCreate");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CreateContact document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(CreateContact.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.contactCreate(rctxt, false, false, false, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLContactRepository#contactAction}<br>
+     * Validates that the contact action request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testContactAction() throws Exception {
+        final ZXMLContactRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLContactRepository.class, "contactAction");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the ContactAction document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(ContactAction.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.contactAction(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLContactRepository#contactModify}<br>
+     * Validates that the modify contact request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testContactModify() throws Exception {
+        final ZXMLContactRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLContactRepository.class, "contactModify");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the ModifyContact document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(ModifyContact.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.contactModify(rctxt, false, false, false, false, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+}

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLFolderRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLFolderRepositoryTest.java
@@ -1,0 +1,242 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.mail.CreateFolder;
+import com.zimbra.cs.service.mail.CreateSearchFolder;
+import com.zimbra.cs.service.mail.GetFolder;
+import com.zimbra.cs.service.mail.GetSearchFolder;
+import com.zimbra.cs.service.mail.ModifySearchFolder;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.type.Folder.View;
+
+
+/**
+ * Test class for {@link ZXMLFolderRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLFolderRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class, "executeDocument", "fromElement", "toElement");
+    }
+
+
+    /**
+     * Test method for {@link ZXMLFolderRepository#folder}<br>
+     * Validates that the folder request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testFolder() throws Exception {
+        final ZXMLFolderRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLFolderRepository.class, "folder");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the GetFolder document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(GetFolder.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.folder(rctxt, false, false, View.MESSAGE, null, false, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLFolderRepository#createFolder}<br>
+     * Validates that the create folder request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testFolderCreate() throws Exception {
+        final ZXMLFolderRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLFolderRepository.class, "createFolder");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CreateFolder document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(CreateFolder.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.createFolder(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLFolderRepository#searchFolderGet}<br>
+     * Validates that the get search folder request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testSearchFolderGet() throws Exception {
+        final ZXMLFolderRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLFolderRepository.class, "searchFolderGet");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the GetSearchFolder document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(GetSearchFolder.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.searchFolderGet(rctxt);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLFolderRepository#searchFolderCreate}<br>
+     * Validates that the create search folder request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testSearchFolderCreate() throws Exception {
+        final ZXMLFolderRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLFolderRepository.class, "searchFolderCreate");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CreateSearchFolder document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(CreateSearchFolder.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.searchFolderCreate(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLFolderRepository#searchFolderModify}<br>
+     * Validates that the modify search folder request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testSearchFolderModify() throws Exception {
+        final ZXMLFolderRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLFolderRepository.class, "searchFolderModify");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CreateSearchFolder document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(ModifySearchFolder.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.searchFolderModify(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+}

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLItemRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLItemRepositoryTest.java
@@ -1,0 +1,146 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.mail.ItemAction;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link ZXMLItemRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLItemRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class, "executeDocument", "fromElement", "toElement");
+    }
+
+
+    /**
+     * Test method for {@link ZXMLItemRepository#action}<br>
+     * Validates that the general action request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAction() throws Exception {
+        final ZXMLItemRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLItemRepository.class, "action");
+        final Object element = new Object();
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(element);
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the ItemAction document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(ItemAction.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.action(rctxt, element);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLItemRepository#itemAction}<br>
+     * Validates that the item action request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testItemAction() throws Exception {
+        final ZXMLItemRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLItemRepository.class, "itemAction");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the ItemAction document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(ItemAction.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.itemAction(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+}

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLMessageRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLMessageRepositoryTest.java
@@ -1,0 +1,145 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.mail.GetMsg;
+import com.zimbra.cs.service.mail.SendMsg;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link ZXMLMessageRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLMessageRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class, "executeDocument", "fromElement", "toElement");
+    }
+
+
+    /**
+     * Test method for {@link ZXMLMessageRepository#message}<br>
+     * Validates that the message request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testMessage() throws Exception {
+        final ZXMLMessageRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLMessageRepository.class, "message");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the GetMsg document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(GetMsg.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.message(rctxt, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLMessageRepository#messageSend}<br>
+     * Validates that the send message request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testMessageSend() throws Exception {
+        final ZXMLMessageRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLMessageRepository.class, "messageSend");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the SendMsg document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(SendMsg.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.messageSend(rctxt, false, false, false, false, null, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+}

--- a/src/java-test/com/zimbra/graphql/resources/GQLServletTest.java
+++ b/src/java-test/com/zimbra/graphql/resources/GQLServletTest.java
@@ -1,0 +1,231 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resources;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.GQLUtilities;
+
+
+/**
+ * Test class for {@link GQLServlet}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, GQLUtilities.class})
+public class GQLServletTest {
+
+    /**
+     * Mock http request for testing.
+     */
+    protected HttpServletRequestWrapper mockRequest;
+
+    /**
+     * Mock http response for testing.
+     */
+    protected HttpServletResponseWrapper mockResponse;
+
+    /**
+     * Object mapper.
+     */
+    protected ObjectMapper mapper = GQLUtilities.createDefaultMapper();
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockRequest = EasyMock.createMock(HttpServletRequestWrapper.class);
+        mockResponse = EasyMock.createMock(HttpServletResponseWrapper.class);
+
+        PowerMock.mockStaticPartial(GQLUtilities.class, "decodeStream");
+    }
+
+
+    /**
+     * Test method for {@link GQLServlet#doGet}<br>
+     * Validates that the doGraphQLRequest is executed and response is sent.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testDoGet() throws Exception {
+        final String query = "fake { name }";
+        final String operationName = null;
+        final String variables = null;
+        final Map<String, Object> gqlResponse = new HashMap<String, Object>();
+        final GQLServlet gqlServlet = PowerMock
+            .createPartialMockForAllMethodsExcept(GQLServlet.class, "doGet");
+
+        // expect to fetch the 3 request parameters
+        expect(mockRequest.getParameter("query")).andReturn(query);
+        expect(mockRequest.getParameter("operationName")).andReturn(operationName);
+        expect(mockRequest.getParameter("variables")).andReturn(variables);
+        // expect to execute the graphql request
+        expect(gqlServlet.doGraphQLRequest(mockRequest, mockResponse, query, operationName, new HashMap<String, Object>())).andReturn(gqlResponse);
+        gqlServlet.sendResponse(mockResponse, gqlResponse);
+        PowerMock.expectLastCall().once();
+
+        replay(gqlServlet);
+        replay(mockRequest);
+
+        gqlServlet.doGet(mockRequest, mockResponse);
+
+        verify(gqlServlet);
+        verify(mockRequest);
+    }
+
+    /**
+     * Test method for {@link GQLServlet#doPost}<br>
+     * Validates that the doGraphQLRequest is executed and response is sent.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testDoPost() throws Exception {
+        final String query = "fake { name }";
+        final String body = String.format("{\"query\": \"%s\"}", query);
+        final Map<String, Object> gqlResponse = new HashMap<String, Object>();
+        final JsonNode json = mapper.readTree(body.getBytes());
+        final GQLServlet gqlServlet = PowerMock
+            .createPartialMockForAllMethodsExcept(GQLServlet.class, "doPost");
+
+        // expect to fetch request input stream
+        expect(mockRequest.getInputStream()).andReturn(null);
+        // expect to decode the request stream
+        GQLUtilities.decodeStream(null, 0);
+        PowerMock.expectLastCall().andReturn(body.getBytes());
+        // expect to read the bytes into json
+        expect(gqlServlet.readBytes(anyObject())).andReturn(json);
+        // expect to execute the graphql request
+        expect(gqlServlet.doGraphQLRequest(mockRequest, mockResponse, query, null, new HashMap<String, Object>())).andReturn(gqlResponse);
+        gqlServlet.sendResponse(mockResponse, gqlResponse);
+        PowerMock.expectLastCall().once();
+
+        replay(gqlServlet);
+        replay(mockRequest);
+        PowerMock.replay(GQLUtilities.class);
+
+        gqlServlet.doPost(mockRequest, mockResponse);
+
+        verify(gqlServlet);
+        verify(mockRequest);
+        PowerMock.verify(GQLUtilities.class);
+    }
+
+    /**
+     * Test method for {@link GQLServlet#doPost}<br>
+     * Validates that the operationName is used when specified.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testDoPostOperationName() throws Exception {
+        final String query = "query TestName { fake { name } }";
+        final String operationName = "TestName";
+        final String body = String.format("{\"query\": \"%s\", \"operationName\": \"%s\"}", query, operationName);
+        final Map<String, Object> gqlResponse = new HashMap<String, Object>();
+        final JsonNode json = mapper.readTree(body.getBytes());
+        final GQLServlet gqlServlet = PowerMock
+            .createPartialMockForAllMethodsExcept(GQLServlet.class, "doPost");
+
+        // expect to fetch request input stream
+        expect(mockRequest.getInputStream()).andReturn(null);
+        // expect to decode the request stream
+        GQLUtilities.decodeStream(null, 0);
+        PowerMock.expectLastCall().andReturn(body.getBytes());
+        // expect to read the bytes into json
+        expect(gqlServlet.readBytes(anyObject())).andReturn(json);
+        // expect to execute the graphql request
+        expect(gqlServlet.doGraphQLRequest(mockRequest, mockResponse, query, operationName, new HashMap<String, Object>())).andReturn(gqlResponse);
+        gqlServlet.sendResponse(mockResponse, gqlResponse);
+        PowerMock.expectLastCall().once();
+
+        replay(gqlServlet);
+        replay(mockRequest);
+        PowerMock.replay(GQLUtilities.class);
+
+        gqlServlet.doPost(mockRequest, mockResponse);
+
+        verify(gqlServlet);
+        verify(mockRequest);
+        PowerMock.verify(GQLUtilities.class);
+    }
+
+    /**
+     * Test method for {@link GQLServlet#doPost}<br>
+     * Validates that the variables argument is used when specified.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testDoPostVariables() throws Exception {
+        final String query = "fake { name }";
+        final String variables = "{\\\"test\\\": \\\"some-value\\\"}";
+        final byte[] bodyBytes = String.format("{\"query\": \"%s\", \"variables\": \"%s\"}", query, variables).trim().getBytes();
+        final Map<String, Object> variablesMap = new HashMap<String, Object>();
+        variablesMap.put("test", "some-value");
+        final Map<String, Object> gqlResponse = new HashMap<String, Object>();
+        final GQLServlet gqlServlet = PowerMock
+            .createPartialMockForAllMethodsExcept(GQLServlet.class, "doPost");
+
+        // expect to fetch the request input stream
+        expect(mockRequest.getInputStream()).andReturn(null);
+        // expect to decode the request stream
+        GQLUtilities.decodeStream(null, 0);
+        PowerMock.expectLastCall().andReturn(bodyBytes);
+        // expect to read the bytes into json
+        expect(gqlServlet.readBytes(bodyBytes)).andReturn(mapper.readTree(bodyBytes));
+        // expect to deserialize the variables string
+        expect(gqlServlet.deserializeVariables(anyObject())).andReturn(variablesMap);
+        // expect to execute the graphql request
+        expect(gqlServlet.doGraphQLRequest(mockRequest, mockResponse, query, null, variablesMap)).andReturn(gqlResponse);
+        gqlServlet.sendResponse(mockResponse, gqlResponse);
+        PowerMock.expectLastCall().once();
+
+        replay(gqlServlet);
+        replay(mockRequest);
+        PowerMock.replay(GQLUtilities.class);
+
+        gqlServlet.doPost(mockRequest, mockResponse);
+
+        verify(gqlServlet);
+        verify(mockRequest);
+        PowerMock.verify(GQLUtilities.class);
+    }
+}

--- a/src/java-test/com/zimbra/graphql/utilities/GQLAuthUtilitiesTest.java
+++ b/src/java-test/com/zimbra/graphql/utilities/GQLAuthUtilitiesTest.java
@@ -1,0 +1,242 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.utilities;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.matches;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertNotNull;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.dom4j.QName;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.common.util.L10nUtil;
+import com.zimbra.common.util.L10nUtil.MsgKey;
+import com.zimbra.cs.account.AuthToken;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.soap.DocumentHandler;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link GQLAuthUtilities}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, ZimbraSoapContext.class})
+public class GQLAuthUtilitiesTest {
+
+    /**
+     * Test method for {@link GQLAuthUtilities#getZimbraSoapContext}<br>
+     * Validates that credentials are valid and a ZimbraSoapContext is created.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testGetZimbraSoapContext() throws Exception {
+        final String authToken = "test-token";
+        final String accountId = "account-id";
+        final Cookie[] cookies = new Cookie[] { new Cookie("ZM_AUTH_TOKEN", authToken) };
+        final AuthToken mockToken = EasyMock.createMock(AuthToken.class);
+        final HttpServletRequest mockRequest = EasyMock.createMock(HttpServletRequest.class);
+        final RequestContext rctxt = new RequestContext();
+        rctxt.setRawRequest(mockRequest);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getAuthToken", "isValidToken");
+
+        // expect to get the accountId from auth token
+        expect(mockToken.getAccountId()).andReturn(accountId);
+        // expect to get the cookies from http request
+        expect(mockRequest.getCookies()).andReturn(cookies);
+        // expect to get the auth header from http request
+        expect(mockRequest.getHeader(matches("Authorization"))).andReturn(authToken);
+        // expect to create an auth token from the headers/cookies
+        GQLAuthUtilities.getAuthToken(EasyMock.eq(cookies), EasyMock.anyObject());
+        PowerMock.expectLastCall().andReturn(mockToken);
+        // expect to validate the auth token
+        GQLAuthUtilities.isValidToken(mockToken);
+        PowerMock.expectLastCall().andReturn(true);
+        // expect to create a new ZimbraSoapContext
+        PowerMock
+            .expectNew(ZimbraSoapContext.class, mockToken, accountId, SoapProtocol.Soap12, SoapProtocol.Soap12)
+            .andReturn(EasyMock.createMock(ZimbraSoapContext.class));
+
+        replay(mockToken);
+        replay(mockRequest);
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(ZimbraSoapContext.class);
+
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+
+        assertNotNull(zsc);
+        verify(mockToken);
+        verify(mockRequest);
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(ZimbraSoapContext.class);
+    }
+
+    /**
+     * Test method for {@link GQLAuthUtilities#getZimbraSoapContext}<br>
+     * Validates that an exception is thrown is credentials are not valid.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test(expected=ServiceException.class)
+    public void testGetZimbraSoapContextInvalidToken() throws Exception {
+        final String authToken = "test-token";
+        final String accountId = "account-id";
+        final Cookie[] cookies = new Cookie[] { new Cookie("ZM_AUTH_TOKEN", authToken) };
+        final AuthToken mockToken = EasyMock.createMock(AuthToken.class);
+        final HttpServletRequest mockRequest = EasyMock.createMock(HttpServletRequest.class);
+        final RequestContext rctxt = new RequestContext();
+        rctxt.setRawRequest(mockRequest);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getAuthToken", "isValidToken");
+
+        // expect to get the accountId from auth token
+        expect(mockToken.getAccountId()).andReturn(accountId);
+        // expect to get the cookies from http request
+        expect(mockRequest.getCookies()).andReturn(cookies);
+        // expect to get the auth header from http request
+        expect(mockRequest.getHeader(matches("Authorization"))).andReturn(authToken);
+        // expect to create an auth token from the headers/cookies
+        GQLAuthUtilities.getAuthToken(EasyMock.eq(cookies), EasyMock.anyObject());
+        PowerMock.expectLastCall().andReturn(mockToken);
+        // expect to validate the auth token
+        GQLAuthUtilities.isValidToken(mockToken);
+        PowerMock.expectLastCall().andReturn(false);
+
+
+        replay(mockToken);
+        replay(mockRequest);
+        PowerMock.replay(GQLAuthUtilities.class);
+
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+    }
+
+    /**
+     * Test method for {@link GQLAuthUtilities#getZimbraSoapContext}<br>
+     * Validates that an exception is thrown if credentials cannot be read from request.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test(expected=ServiceException.class)
+    public void testGetZimbraSoapContextMissingOrUnreadableToken() throws Exception {
+        final String authToken = "test-token";
+        final String accountId = "account-id";
+        final Cookie[] cookies = new Cookie[] { new Cookie("ZM_AUTH_TOKEN", authToken) };
+        final AuthToken mockToken = EasyMock.createMock(AuthToken.class);
+        final HttpServletRequest mockRequest = EasyMock.createMock(HttpServletRequest.class);
+        final RequestContext rctxt = new RequestContext();
+        rctxt.setRawRequest(mockRequest);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getAuthToken", "isValidToken");
+
+        // expect to get the accountId from auth token
+        expect(mockToken.getAccountId()).andReturn(accountId);
+        // expect to get the cookies from http request
+        expect(mockRequest.getCookies()).andReturn(cookies);
+        // expect to get the auth header from http request
+        expect(mockRequest.getHeader(matches("Authorization"))).andReturn(authToken);
+        // expect to fail creating an auth token from the headers/cookies
+        GQLAuthUtilities.getAuthToken(EasyMock.eq(cookies), EasyMock.anyObject());
+        PowerMock.expectLastCall()
+            .andThrow(ServiceException.PERM_DENIED(L10nUtil.getMessage(MsgKey.errMustAuthenticate)));
+
+
+        replay(mockToken);
+        replay(mockRequest);
+        PowerMock.replay(GQLAuthUtilities.class);
+
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+    }
+
+    /**
+     * Test method for {@link GQLAuthUtilities#getGuestZimbraSoapContext}<br>
+     * Validates that a ZimbraSoapContext is created with request info.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testGetGuestZimbraSoapContext() throws Exception {
+        final String userAgent = "junit";
+        final String remoteAddr = "remote.addr";
+        final int remotePort = 80;
+        final QName qName = EasyMock.createMock(QName.class);
+        final DocumentHandler handler = EasyMock.createMock(DocumentHandler.class);
+        final HttpServletRequest mockRequest = EasyMock.createMock(HttpServletRequest.class);
+        final RequestContext rctxt = new RequestContext();
+        rctxt.setRawRequest(mockRequest);
+
+        // expect to get the remote address from http request
+        expect(mockRequest.getRemoteAddr()).andReturn(remoteAddr);
+        // expect to get the remote port from http request
+        expect(mockRequest.getRemotePort()).andReturn(remotePort);
+        // expect to get the user agent header from http request
+        expect(mockRequest.getHeader(HttpHeaders.USER_AGENT)).andReturn(userAgent);
+        // expect to create a new ZimbraSoapContext
+        PowerMock
+            .expectNew(ZimbraSoapContext.class, anyObject(Element.class), eq(qName), eq(handler),
+                anyObject(), eq(SoapProtocol.Soap12))
+            .andReturn(EasyMock.createMock(ZimbraSoapContext.class));
+
+        replay(mockRequest);
+        PowerMock.replay(ZimbraSoapContext.class);
+
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getGuestZimbraSoapContext(qName, handler, rctxt);
+
+        assertNotNull(zsc);
+        PowerMock.verify(ZimbraSoapContext.class);
+    }
+
+    /**
+     * Test method for {@link GQLAuthUtilities#getGuestZimbraSoapContext}<br>
+     * Validates that an exception is thrown if the handler is null.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test(expected=ServiceException.class)
+    public void testGetGuestZimbraSoapContextNullHandler() throws Exception {
+        GQLAuthUtilities.getGuestZimbraSoapContext(EasyMock.createMock(QName.class), null, null);
+    }
+
+    /**
+     * Test method for {@link GQLAuthUtilities#getGuestZimbraSoapContext}<br>
+     * Validates that an exception is thrown if the QName is null.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test(expected=ServiceException.class)
+    public void testGetGuestZimbraSoapContextNullQName() throws Exception {
+        GQLAuthUtilities.getGuestZimbraSoapContext(null, EasyMock.createMock(DocumentHandler.class), null);
+    }
+
+}

--- a/src/java-test/com/zimbra/graphql/utilities/XMLDocumentUtilitiesTest.java
+++ b/src/java-test/com/zimbra/graphql/utilities/XMLDocumentUtilitiesTest.java
@@ -1,0 +1,113 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.utilities;
+
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dom4j.QName;
+import org.easymock.EasyMock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.AccountConstants;
+import com.zimbra.common.soap.Element;
+import com.zimbra.common.soap.SoapProtocol;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.soap.DocumentHandler;
+import com.zimbra.soap.SoapEngine;
+import com.zimbra.soap.SoapServlet;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link XMLDocumentUtilities}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, ZimbraSoapContext.class})
+public class XMLDocumentUtilitiesTest {
+
+    /**
+     * Test method for {@link XMLDocumentUtilities#executeDocumentAsGuest}<br>
+     * Validates that the request is executed using the handler and a guest soap context.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testExecuteDocumentAsGuest() throws Exception {
+        final QName qName = AccountConstants.AUTH_REQUEST;
+        final ZimbraSoapContext mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        final DocumentHandler handler = EasyMock.createMock(DocumentHandler.class);
+        final RequestContext rctxt = new RequestContext();
+        final Element request = Element.create(SoapProtocol.Soap12, qName);
+        final Map<String, Object> context = new HashMap<String, Object>();
+        context.put(SoapEngine.ZIMBRA_CONTEXT, mockZsc);
+        context.put(SoapServlet.SERVLET_REQUEST, rctxt.getRawRequest());
+        context.put(SoapServlet.SERVLET_RESPONSE, rctxt.getRawResponse());
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getGuestZimbraSoapContext");
+
+        // expect to create a guest zimbra soap context
+        GQLAuthUtilities.getGuestZimbraSoapContext(request.getQName(), handler, rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to handle the request with the necessary context params
+        expect(handler.handle(eq(request), eq(context))).andReturn(null);
+
+        replay(handler);
+        PowerMock.replay(GQLAuthUtilities.class);
+
+        XMLDocumentUtilities.executeDocumentAsGuest(handler, rctxt, request);
+
+        verify(handler);
+        PowerMock.verify(GQLAuthUtilities.class);
+    }
+
+    /**
+     * Test method for {@link XMLDocumentUtilities#executeDocument}<br>
+     * Validates that the request is executed using the handler and specified soap context.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testExecuteDocument() throws Exception {
+        final ZimbraSoapContext mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        final DocumentHandler handler = EasyMock.createMock(DocumentHandler.class);
+        final RequestContext rctxt = new RequestContext();
+        final Element request = Element.create(SoapProtocol.Soap12, AccountConstants.AUTH_REQUEST);
+        final Map<String, Object> context = new HashMap<String, Object>();
+        context.put(SoapEngine.ZIMBRA_CONTEXT, mockZsc);
+        context.put(SoapServlet.SERVLET_REQUEST, rctxt.getRawRequest());
+
+        // expect to handle the request with the necessary context params
+        expect(handler.handle(eq(request), eq(context))).andReturn(null);
+
+        replay(handler);
+
+        XMLDocumentUtilities.executeDocument(handler, mockZsc, request, rctxt);
+
+        verify(handler);
+    }
+
+}

--- a/src/java-test/com/zimbra/graphql/utilities/XMLDocumentUtilitiesTest.java
+++ b/src/java-test/com/zimbra/graphql/utilities/XMLDocumentUtilitiesTest.java
@@ -78,7 +78,7 @@ public class XMLDocumentUtilitiesTest {
         replay(handler);
         PowerMock.replay(GQLAuthUtilities.class);
 
-        XMLDocumentUtilities.executeDocumentAsGuest(handler, rctxt, request);
+        XMLDocumentUtilities.executeDocumentAsGuest(handler, request, rctxt);
 
         verify(handler);
         PowerMock.verify(GQLAuthUtilities.class);

--- a/src/java-test/log4j-test.properties
+++ b/src/java-test/log4j-test.properties
@@ -1,0 +1,7 @@
+log4j.debug=false
+
+log4j.rootLogger=OFF, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
@@ -331,17 +331,17 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
 
     /**
      * Modifies the selected account password.
-     *
+     * @param rctxt The request context
      * @param acctSelector The account for which password is changed
      * @param oldPassword old Password
      * @param newPassword new password
      * @param virtualHost virtualHost
-     * @param rctxt The request context
+     *
      * @return Change password response
      * @throws ServiceException If there are issues executing the document
      */
-    public ChangePasswordResponse changePassword(AccountSelector acctSelector, String oldPassword,
-        String newPassword, String virtualHost, RequestContext rctxt) throws ServiceException {
+    public ChangePasswordResponse changePassword(RequestContext rctxt, AccountSelector acctSelector,
+        String oldPassword, String newPassword, String virtualHost) throws ServiceException {
         final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
         final ChangePasswordRequest request = new ChangePasswordRequest();
         request.setOldPassword(oldPassword);

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAuthRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAuthRepository.java
@@ -89,8 +89,8 @@ public class ZXMLAuthRepository extends ZXMLRepository implements IRepository {
         // execute
         final Element response = XMLDocumentUtilities.executeDocumentAsGuest(
             authHandler,
-            rctxt,
-            XMLDocumentUtilities.toElement(req));
+            XMLDocumentUtilities.toElement(req),
+            rctxt);
         AuthResponse zAuthResponse = null;
         if (response != null) {
             zAuthResponse = XMLDocumentUtilities

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -109,7 +109,7 @@ public class AccountResolver {
         @GraphQLArgument(name = GqlConstants.VIRTUAL_HOST,
         description = "The virtual host to indicae domain for the account.") String virtualHost,
         @GraphQLNonNull @GraphQLRootContext RequestContext context) throws ServiceException {
-        return accountRepository.changePassword(accountInput, password, oldPassword, virtualHost, context);
+        return accountRepository.changePassword(context, accountInput, password, oldPassword, virtualHost);
     }
 
     @GraphQLQuery(description="Retrieves white and black list entries")

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -127,7 +127,7 @@ public class GQLServlet extends ExtensionHttpHandler {
         try {
             // read the body into json
             ZimbraLog.extensions.debug("Reading http body.");
-            final JsonNode jsonBody = mapper.readTree(GQLUtilities.decodeStream(req.getInputStream(), 0));
+            final JsonNode jsonBody = readBytes(GQLUtilities.decodeStream(req.getInputStream(), 0));
             if (jsonBody != null && !jsonBody.isNull()) {
                 // seek query param (string)
                 if (jsonBody.has("query")) {
@@ -250,13 +250,24 @@ public class GQLServlet extends ExtensionHttpHandler {
     }
 
     /**
+     * Translates bytes to json.
+     *
+     * @param bytes The bytes to read
+     * @return Json representation
+     * @throws IOException If there are parsing issues
+     */
+    protected JsonNode readBytes(byte[] bytes) throws IOException {
+        return mapper.readTree(bytes);
+    }
+
+    /**
      * Utility to deserialize variables from string.
      *
      * @param variables The variables to deserialize
      * @return A map of the variables
      * @throws ServiceException If there are issues deserializing
      */
-    private Map<String, Object> deserializeVariables(String variables) throws ServiceException {
+    protected Map<String, Object> deserializeVariables(String variables) throws ServiceException {
         try {
             return deserializeVariablesObject(mapper.readValue(variables, Object.class));
         } catch (final IOException e) {

--- a/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
+++ b/src/java/com/zimbra/graphql/utilities/XMLDocumentUtilities.java
@@ -46,12 +46,12 @@ public class XMLDocumentUtilities {
      * validating auth credentials.
      *
      * @param handler The handler to handle the request
-     * @param rctxt The graphql context for the request
      * @param request The request to execute
+     * @param rctxt The graphql context for the request
      * @return The document response
      * @throws ServiceException If there are issues executing the document
      */
-    public static Element executeDocumentAsGuest(DocumentHandler handler, RequestContext rctxt, Element request)
+    public static Element executeDocumentAsGuest(DocumentHandler handler, Element request, RequestContext rctxt)
         throws ServiceException {
         final Map<String, Object> context = new HashMap<String, Object>();
         context.put(SoapEngine.ZIMBRA_CONTEXT,


### PR DESCRIPTION
* Added base unit tests for repositories, utilities, and servlet.
* Modified scope on some methods for ease of testing
* Wrapped json reading for ease of testing.
* Shifted `ZXMLAccountRepository#changePassword` signature param to match the others
* Shifted `XMLDocumentUtilities#executeDocumentAsGuest` signature to match the update `executeDocument` signature.
* Updated README.md
