### PR TITLE
ZCS-6137 Implement auto-complete API.

### DIFF
--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLSearchRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLSearchRepositoryTest.java
@@ -29,12 +29,14 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.zimbra.common.soap.Element;
-import com.zimbra.cs.service.mail.GetMsg;
+import com.zimbra.cs.service.mail.AutoComplete;
+import com.zimbra.cs.service.mail.Search;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLSearchRequestInput;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
 import com.zimbra.graphql.utilities.XMLDocumentUtilities;
 import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.type.GalSearchType;
 
 
 /**
@@ -98,9 +100,9 @@ public class ZXMLSearchRepositoryTest {
         // expect to unmarshall a request
         XMLDocumentUtilities.toElement(anyObject());
         PowerMock.expectLastCall().andReturn(mockRequest);
-        // expect to execute an element on the GetMsg document handler
+        // expect to execute an element on the Search document handler
         expect(XMLDocumentUtilities
-                .executeDocument(anyObject(GetMsg.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+                .executeDocument(anyObject(Search.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
             .andReturn(mockResponse);
         // expect to marshall a response
         XMLDocumentUtilities.fromElement(eq(mockResponse), anyObject());
@@ -115,4 +117,34 @@ public class ZXMLSearchRepositoryTest {
         PowerMock.verify(XMLDocumentUtilities.class);
     }
 
+    /**
+     * Test method for {@link ZXMLSearchRepository#autoComplete}<br>
+     * Validates that the auto-complete request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAutoComplete() throws Exception {
+        final ZXMLSearchRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLSearchRepository.class, "autoComplete");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the AutoComplete document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(AutoComplete.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.autoComplete(rctxt, "test-name", GalSearchType.all, false, "", false);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
 }

--- a/src/java/com/zimbra/graphql/models/outputs/GQLAutoCompleteResponse.java
+++ b/src/java/com/zimbra/graphql/models/outputs/GQLAutoCompleteResponse.java
@@ -1,0 +1,60 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.outputs;
+
+import java.util.List;
+
+import com.zimbra.common.gql.GqlConstants;
+import com.zimbra.soap.mail.type.AutoCompleteMatch;
+
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLAutoCompleteResponse class.<br>
+ * Contains auto-complete response information.
+ * @see com.zimbra.soap.mail.message.AutoCompleteResponse
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.outputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name=GqlConstants.CLASS_AUTO_COMPLETE_RESPONSE, description="Contains auto-complete response information")
+public class GQLAutoCompleteResponse {
+
+    protected Boolean isCacheable;
+    protected List<AutoCompleteMatch> matches;
+
+    @GraphQLQuery(name=GqlConstants.IS_CACHEABLE, description="Denotes whether this response can be cached")
+    public Boolean getIsCacheable() {
+        return isCacheable;
+    }
+
+    public void setIsCacheable(Boolean isCacheable) {
+        this.isCacheable = isCacheable;
+    }
+
+    @GraphQLQuery(name=GqlConstants.MATCHES, description="List of matches")
+    public List<AutoCompleteMatch> getMatches() {
+        return matches;
+    }
+
+    public void setMatches(List<AutoCompleteMatch> matches) {
+        this.matches = matches;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
@@ -21,9 +21,11 @@ import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLSearchRequestInput;
+import com.zimbra.graphql.models.outputs.GQLAutoCompleteResponse;
 import com.zimbra.graphql.models.outputs.GQLConversationSearchResponse;
 import com.zimbra.graphql.models.outputs.GQLMessageSearchResponse;
 import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
+import com.zimbra.soap.type.GalSearchType;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLNonNull;
@@ -53,18 +55,27 @@ public class SearchResolver {
 
     @GraphQLQuery(description = "Search for messages with the given properties.")
     public GQLMessageSearchResponse messageSearch(
-            @GraphQLNonNull @GraphQLArgument(name=GqlConstants.SEARCH_PARAMS, description="Input parameters for the search") GQLSearchRequestInput searchInput,
-            @GraphQLRootContext RequestContext context
-            ) throws ServiceException {
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.SEARCH_PARAMS, description="Input parameters for the search") GQLSearchRequestInput searchInput,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
         return searchRepository.messageSearch(context, searchInput);
     }
 
     @GraphQLQuery(description = "Search for conversations with the given properties.")
     public GQLConversationSearchResponse conversationSearch(
-            @GraphQLNonNull @GraphQLArgument(name=GqlConstants.SEARCH_PARAMS, description="Input parameters for the search") GQLSearchRequestInput searchInput,
-            @GraphQLRootContext RequestContext context
-            ) throws ServiceException {
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.SEARCH_PARAMS, description="Input parameters for the search") GQLSearchRequestInput searchInput,
+        @GraphQLRootContext RequestContext context) throws ServiceException {
         return searchRepository.conversationSearch(context, searchInput);
+    }
+
+    @GraphQLQuery(description = "Search for auto-complete matches.")
+    public GQLAutoCompleteResponse autoComplete(
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.NAME, description="Name") String name,
+        @GraphQLArgument(name=GqlConstants.TYPE, description="Type of addresses to auto-complete on") GalSearchType type,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_IS_EXPANDABLE, description="Denotes whether to include `isExpandable` flag for group entries", defaultValue="false") Boolean includeIsExpandable,
+        @GraphQLArgument(name=GqlConstants.FOLDERS, description="Comma-separated list of folder ids") String folders,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_GAL, description="Denotes whether to search the global address list") Boolean includeGal,
+        @GraphQLRootContext RequestContext rctxt) throws ServiceException {
+        return searchRepository.autoComplete(rctxt, name, type, includeIsExpandable, folders, includeGal);
     }
 
 }


### PR DESCRIPTION
* Added support for auto-complete API
* Added unit tests

I would have preferred to change the implementation slightly here to consider an interface for the match types and look at connections, but because of time and version constraints, leaving it as is for now.

See associated PR:
Zimbra/zm-mailbox#814

**Testing Done**
See jira for queries.

**Testing to be done by QA**
See testrail.