### PR TITLE
ZCS-6144:Create Resource and Resolver classes for Smime certificate

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -22,6 +22,7 @@
       <dependency org="zimbra" name="zm-client" rev="latest.integration" />
       <dependency org="zimbra" name="zm-soap" rev="latest.integration" />
       <dependency org="zimbra" name="zm-store" rev="latest.integration" />
+      <dependency org="zimbra" name="zm-network-store" rev="latest.integration" />
       <!-- Test Requirements -->
       <dependency org="junit" name="junit" rev="4.8.2" />
       <dependency org="org.powermock" name="powermock-core" rev="1.6.5" />

--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAccountRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLAccountRepositoryTest.java
@@ -34,6 +34,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.account.AuthToken;
+import com.zimbra.cs.network.GetSMIMEPublicCerts;
 import com.zimbra.cs.service.account.ChangePassword;
 import com.zimbra.cs.service.account.CreateSignature;
 import com.zimbra.cs.service.account.DeleteSignature;
@@ -53,6 +54,8 @@ import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.account.message.CreateSignatureResponse;
 import com.zimbra.soap.account.type.NameId;
 import com.zimbra.soap.account.type.Signature;
+import com.zimbra.soap.type.SourceLookupOpt;
+import com.zimbra.soap.type.StoreLookupOpt;
 
 
 /**
@@ -486,6 +489,37 @@ public class ZXMLAccountRepositoryTest {
        PowerMock.replay(XMLDocumentUtilities.class);
 
        repository.signatureDelete(rctxt, new NameId(null, "sig-id"));
+
+       PowerMock.verify(GQLAuthUtilities.class);
+       PowerMock.verify(XMLDocumentUtilities.class);
+   }
+
+   /**
+    * Test method for {@link ZXMLAccountRepository#smimePublicCertificates}<br>
+    * Validates that the smimePublicCertificates request is executed.
+    *
+    * @throws Exception If there are issues
+    */
+   @Test
+   public void testSmimePublicCertificates() throws Exception {
+       final ZXMLAccountRepository repository = PowerMock
+           .createPartialMockForAllMethodsExcept(ZXMLAccountRepository.class, "smimePublicCertificates");
+
+       // expect to create a zimbra soap context
+       GQLAuthUtilities.getZimbraSoapContext(rctxt);
+       PowerMock.expectLastCall().andReturn(mockZsc);
+       // expect to unmarshall a request
+       XMLDocumentUtilities.toElement(anyObject());
+       PowerMock.expectLastCall().andReturn(mockRequest);
+       // expect to execute an element on the GetSMIMEPublicCerts document handler
+       expect(XMLDocumentUtilities
+               .executeDocument(anyObject(GetSMIMEPublicCerts.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+           .andReturn(null);
+
+       PowerMock.replay(GQLAuthUtilities.class);
+       PowerMock.replay(XMLDocumentUtilities.class);
+
+       repository.smimePublicCertificates(rctxt, StoreLookupOpt.ANY, SourceLookupOpt.ALL, Collections.emptyList(), Collections.emptyList());
 
        PowerMock.verify(GQLAuthUtilities.class);
        PowerMock.verify(XMLDocumentUtilities.class);

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -29,9 +29,13 @@ import com.zimbra.soap.account.message.ChangePasswordResponse;
 import com.zimbra.soap.account.message.GetInfoResponse;
 import com.zimbra.soap.account.type.NameId;
 import com.zimbra.soap.account.type.Pref;
+import com.zimbra.soap.account.type.SMIMEPublicCertsInfo;
 import com.zimbra.soap.account.type.Signature;
 import com.zimbra.soap.type.AccountSelector;
 import com.zimbra.soap.type.OpValue;
+import com.zimbra.soap.type.SMIMEStoreType;
+import com.zimbra.soap.type.SourceLookupOpt;
+import com.zimbra.soap.type.StoreLookupOpt;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLMutation;
@@ -148,5 +152,15 @@ public class AccountResolver {
     public Boolean signatureDelete(@GraphQLNonNull @GraphQLArgument(name=GqlConstants.IDENTIFIER) NameId identifier,
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return accountRepository.signatureDelete(context, identifier);
+    }
+
+    @GraphQLQuery(description="Get SMIME Public Certificates")
+    public List<SMIMEPublicCertsInfo> smimePublicCertificates(
+            @GraphQLArgument(name=GqlConstants.STORE_LOOKUP_OPT, description="Lookup option related to stores, default value ANY") StoreLookupOpt storeLookupOption,
+            @GraphQLArgument(name=GqlConstants.SOURCE_LOOKUP_OPT, description="Lookup option related to sources configured for stores, default value ALL") SourceLookupOpt sourceLookupOption,
+            @GraphQLNonNull @GraphQLArgument(name=GqlConstants.STORE_TYPES, description="certificate stores") List<SMIMEStoreType> storeTypes,
+            @GraphQLNonNull @GraphQLArgument(name=GqlConstants.EMAIL, description="List of email addresses") List<String> emails,
+            @GraphQLRootContext RequestContext context) throws ServiceException {
+        return accountRepository.smimePublicCertificates(context, storeLookupOption, sourceLookupOption, storeTypes, emails);
     }
 }


### PR DESCRIPTION
Added support for GetSMIMEPublicCerts.
GetSMIMEPublicCerts is network edition API, Hence it's handler resides in zm-network-store. 
Added dependency on zm-network-store temporarily till we have some concrete design for the graph QL network API(not in scope of current ticket). 
The change is targeted for feature branch, it will be merged to develop after the final solution.