### PR TITLE
ZCS-6138 Implement calendar repository.

### DIFF
--- a/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLCalendarRepositoryTest.java
+++ b/src/java-test/com/zimbra/graphql/repositories/impl/ZXMLCalendarRepositoryTest.java
@@ -1,0 +1,241 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.mail.CancelAppointment;
+import com.zimbra.cs.service.mail.CreateAppointment;
+import com.zimbra.cs.service.mail.CreateAppointmentException;
+import com.zimbra.cs.service.mail.ModifyAppointment;
+import com.zimbra.cs.service.mail.SendInviteReply;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.inputs.GQLInviteReplyVerbInput;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+
+
+/**
+ * Test class for {@link ZXMLCalendarRepository}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLAuthUtilities.class, XMLDocumentUtilities.class, ZimbraSoapContext.class})
+public class ZXMLCalendarRepositoryTest {
+
+    /**
+     * Mock soap context for testing.
+     */
+    protected ZimbraSoapContext mockZsc;
+
+    /**
+     * Mock request element for testing.
+     */
+    protected Element mockRequest;
+
+    /**
+     * Mock response element for testing.
+     */
+    protected Element mockResponse;
+
+    /**
+     * Mock request context for testing.
+     */
+    protected RequestContext rctxt;
+
+    /**
+     * Setup for tests.
+     *
+     * @throws Exception If there are issues mocking
+     */
+    @Before
+    public void setUp() throws Exception {
+        mockZsc = EasyMock.createMock(ZimbraSoapContext.class);
+        mockRequest = EasyMock.createMock(Element.class);
+        mockResponse = EasyMock.createMock(Element.class);
+        rctxt = EasyMock.createMock(RequestContext.class);
+
+        PowerMock.mockStaticPartial(GQLAuthUtilities.class, "getZimbraSoapContext");
+        PowerMock.mockStaticPartial(XMLDocumentUtilities.class, "executeDocument", "fromElement", "toElement");
+    }
+
+    /**
+     * Test method for {@link ZXMLCalendarRepository#appointmentCreate}<br>
+     * Validates that the create appointment request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAppointmentCreate() throws Exception {
+        final ZXMLCalendarRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLCalendarRepository.class, "appointmentCreate");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CreateAppointment document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(CreateAppointment.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.appointmentCreate(rctxt, false, 0, false, false, false, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLCalendarRepository#appointmentExceptionCreate}<br>
+     * Validates that the create appointment exception request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAppointmentExceptionCreate() throws Exception {
+        final ZXMLCalendarRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLCalendarRepository.class, "appointmentExceptionCreate");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CreateAppointmentException document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(CreateAppointmentException.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.appointmentExceptionCreate(rctxt, "some-id", 0, 0, 0, false, 0, false, false, false, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLCalendarRepository#appointmentModify}<br>
+     * Validates that the modify appointment request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAppointmentModify() throws Exception {
+        final ZXMLCalendarRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLCalendarRepository.class, "appointmentModify");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the ModifyAppointment document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(ModifyAppointment.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.appointmentModify(rctxt, "some-id", 0, 0, 0, false, 0, false, false, false, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLCalendarRepository#inviteReply}<br>
+     * Validates that the invite reply request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testInviteReply() throws Exception {
+        final ZXMLCalendarRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLCalendarRepository.class, "inviteReply");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the SendInviteReply document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(SendInviteReply.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.inviteReply(rctxt, "some-id", 0, GQLInviteReplyVerbInput.ACCEPT, false, "ident", null, null, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+
+    /**
+     * Test method for {@link ZXMLCalendarRepository#appointmentCancel}<br>
+     * Validates that the cancel appointment request is executed.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testAppointmentCancel() throws Exception {
+        final ZXMLCalendarRepository repository = PowerMock
+            .createPartialMockForAllMethodsExcept(ZXMLCalendarRepository.class, "appointmentCancel");
+
+        // expect to create a zimbra soap context
+        GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        PowerMock.expectLastCall().andReturn(mockZsc);
+        // expect to unmarshall a request
+        XMLDocumentUtilities.toElement(anyObject());
+        PowerMock.expectLastCall().andReturn(mockRequest);
+        // expect to execute an element on the CancelAppointment document handler
+        expect(XMLDocumentUtilities
+                .executeDocument(anyObject(CancelAppointment.class), eq(mockZsc), eq(mockRequest), eq(rctxt)))
+            .andReturn(null);
+
+        PowerMock.replay(GQLAuthUtilities.class);
+        PowerMock.replay(XMLDocumentUtilities.class);
+
+        repository.appointmentCancel(rctxt,"some-id", 0, 0, 0, null, null, null);
+
+        PowerMock.verify(GQLAuthUtilities.class);
+        PowerMock.verify(XMLDocumentUtilities.class);
+    }
+}

--- a/src/java/com/zimbra/graphql/models/inputs/GQLInviteReplyVerbInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLInviteReplyVerbInput.java
@@ -1,0 +1,36 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.models.inputs;
+import com.zimbra.common.gql.GqlConstants;
+
+import io.leangen.graphql.annotations.types.GraphQLType;
+
+/**
+ * The GQLInviteReplyVerbInput enum.<br>
+ * Contains verbs for calendar invite reply.
+ * @see com.zimbra.soap.mail.message.SendInviteReplyRequest
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.models.inputs
+ * @copyright Copyright © 2018
+ */
+@GraphQLType(name=GqlConstants.CLASS_INVITE_REPLY_VERB_INPUT, description="Verbs for send invite reply.")
+public enum GQLInviteReplyVerbInput {
+    ACCEPT,
+    DECLINE,
+    TENTATIVE
+}

--- a/src/java/com/zimbra/graphql/models/inputs/GQLInviteReplyVerbInput.java
+++ b/src/java/com/zimbra/graphql/models/inputs/GQLInviteReplyVerbInput.java
@@ -17,6 +17,7 @@
 package com.zimbra.graphql.models.inputs;
 import com.zimbra.common.gql.GqlConstants;
 
+import io.leangen.graphql.annotations.GraphQLEnumValue;
 import io.leangen.graphql.annotations.types.GraphQLType;
 
 /**
@@ -30,7 +31,7 @@ import io.leangen.graphql.annotations.types.GraphQLType;
  */
 @GraphQLType(name=GqlConstants.CLASS_INVITE_REPLY_VERB_INPUT, description="Verbs for send invite reply.")
 public enum GQLInviteReplyVerbInput {
-    ACCEPT,
-    DECLINE,
-    TENTATIVE
+    @GraphQLEnumValue(description="Accept reply") ACCEPT,
+    @GraphQLEnumValue(description="Decline reply") DECLINE,
+    @GraphQLEnumValue(description="Tentative reply") TENTATIVE
 }

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLCalendarRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLCalendarRepository.java
@@ -1,0 +1,311 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.repositories.impl;
+
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.Element;
+import com.zimbra.cs.service.mail.CancelAppointment;
+import com.zimbra.cs.service.mail.CreateAppointment;
+import com.zimbra.cs.service.mail.CreateAppointmentException;
+import com.zimbra.cs.service.mail.ModifyAppointment;
+import com.zimbra.cs.service.mail.SendInviteReply;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.inputs.GQLInviteReplyVerbInput;
+import com.zimbra.graphql.repositories.IRepository;
+import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.XMLDocumentUtilities;
+import com.zimbra.soap.ZimbraSoapContext;
+import com.zimbra.soap.mail.message.CancelAppointmentRequest;
+import com.zimbra.soap.mail.message.CreateAppointmentExceptionRequest;
+import com.zimbra.soap.mail.message.CreateAppointmentExceptionResponse;
+import com.zimbra.soap.mail.message.CreateAppointmentRequest;
+import com.zimbra.soap.mail.message.CreateAppointmentResponse;
+import com.zimbra.soap.mail.message.ModifyAppointmentRequest;
+import com.zimbra.soap.mail.message.ModifyAppointmentResponse;
+import com.zimbra.soap.mail.message.SendInviteReplyRequest;
+import com.zimbra.soap.mail.message.SendInviteReplyResponse;
+import com.zimbra.soap.mail.type.CalTZInfo;
+import com.zimbra.soap.mail.type.DtTimeInfo;
+import com.zimbra.soap.mail.type.InstanceRecurIdInfo;
+import com.zimbra.soap.mail.type.Msg;
+
+/**
+ * The ZXMLCalendarRepository class.<br>
+ * Contains XML document based data access methods for calendar.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.repositories.impl
+ * @copyright Copyright © 2018
+ */
+public class ZXMLCalendarRepository extends ZXMLRepository implements IRepository {
+
+    /**
+     * The createAppointment document handler.
+     */
+    protected final CreateAppointment createAppointmentHandler;
+
+    /**
+     * The createAppointmentException document handler.
+     */
+    protected final CreateAppointmentException createAppointmentExceptionHandler;
+
+    /**
+     * The modifyAppointment document handler.
+     */
+    protected final ModifyAppointment modifyAppointmentHandler;
+
+    /**
+     * The cancelAppointment document handler.
+     */
+    protected final CancelAppointment cancelAppointmentHandler;
+
+    /**
+     * The inviteReply document handler.
+     */
+    protected final SendInviteReply inviteReplyHandler;
+
+    /**
+     * Creates an instance with default document handlers.
+     */
+    public ZXMLCalendarRepository() {
+        this(new CreateAppointment(), new CreateAppointmentException(),
+            new ModifyAppointment(), new CancelAppointment(), new SendInviteReply());
+    }
+
+    /**
+     * Creates an instance with specified handlers.
+     *
+     * @param createAppointmentHandler The createAppointment handler
+     * @param createAppointmentExceptionHandler The createAppointmentException handler
+     * @param modifyAppointment The modifyAppointment handler
+     * @param cancelAppointmentHandler The cancelAppointment handler
+     * @param sendInviteReplyHandler The inviteReply handler
+     */
+    public ZXMLCalendarRepository(CreateAppointment createAppointmentHandler,
+        CreateAppointmentException createAppointmentExceptionHandler,
+        ModifyAppointment modifyAppointmentHandler, CancelAppointment cancelAppointmentHandler,
+        SendInviteReply inviteReplyHandler) {
+        super();
+        this.createAppointmentHandler = createAppointmentHandler;
+        this.createAppointmentExceptionHandler = createAppointmentExceptionHandler;
+        this.modifyAppointmentHandler = modifyAppointmentHandler;
+        this.cancelAppointmentHandler = cancelAppointmentHandler;
+        this.inviteReplyHandler = inviteReplyHandler;
+    }
+
+    /**
+     * Creates an appointment.
+     *
+     * @param rctxt The request context
+     * @param includeEcho Denotes whether to return created appointment in the response
+     * @param maxSize Maximum inline length
+     * @param includeHtml Denotes whether to include html in response echo
+     * @param doNeuter Denotes whether to neuter elements of the echo (e.g. images)
+     * @param doForce Denotes whether to force send the messag
+     * @param message Message
+     * @return Create appointment response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public CreateAppointmentResponse appointmentCreate(RequestContext rctxt, Boolean includeEcho, Integer maxSize,
+        Boolean includeHtml, Boolean doNeuter, Boolean doForce, Msg message) throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final CreateAppointmentRequest request = new CreateAppointmentRequest();
+        request.setEcho(includeEcho);
+        request.setWantHtml(includeHtml);
+        request.setMaxSize(maxSize);
+        request.setNeuter(doNeuter);
+        request.setForceSend(doForce);
+        request.setMsg(message);
+        final Element response = XMLDocumentUtilities.executeDocument(
+            createAppointmentHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
+        CreateAppointmentResponse resp = null;
+        if (response != null) {
+            resp = XMLDocumentUtilities.fromElement(response,
+                CreateAppointmentResponse.class);
+        }
+        return resp;
+    }
+
+    /**
+     * Creates an appointment exception.
+     *
+     * @param rctxt The request context
+     * @param id Invite ID of default invite
+     * @param componentNumber Component number of default component
+     * @param modifiedSequence Change sequence of fetched version. Used for conflict detection
+     * @param revision Revision
+     * @param includeEcho Denotes whether to return created appointment in the response
+     * @param maxSize Maximum inline length
+     * @param includeHtml Denotes whether to include html in response echo
+     * @param doNeuter Denotes whether to neuter elements of the echo (e.g. images)
+     * @param doForce Denotes whether to force send the messag
+     * @param message Message
+     * @return Create appointment exception response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public CreateAppointmentExceptionResponse appointmentExceptionCreate(RequestContext rctxt, String id,
+        Integer componentNumber, Integer modifiedSequence, Integer revision, Boolean includeEcho, Integer maxSize,
+        Boolean includeHtml, Boolean doNeuter, Boolean doForce, Msg message) throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final CreateAppointmentExceptionRequest request = new CreateAppointmentExceptionRequest();
+        request.setId(id);
+        request.setNumComponents(componentNumber);
+        request.setModifiedSequence(modifiedSequence);
+        request.setRevision(revision);
+        request.setEcho(includeEcho);
+        request.setWantHtml(includeHtml);
+        request.setMaxSize(maxSize);
+        request.setNeuter(doNeuter);
+        request.setForceSend(doForce);
+        request.setMsg(message);
+        final Element response = XMLDocumentUtilities.executeDocument(
+            createAppointmentExceptionHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
+        CreateAppointmentExceptionResponse resp = null;
+        if (response != null) {
+            resp = XMLDocumentUtilities.fromElement(response,
+                CreateAppointmentExceptionResponse.class);
+        }
+        return resp;
+    }
+
+    /**
+     * Modifies an appointment.
+     *
+     * @param rctxt The request context
+     * @param id Invite ID of default invite
+     * @param componentNumber Component number of default invite
+     * @param modifiedSequence Change sequence of fetched version. Used for conflict detection
+     * @param revision Revision
+     * @param includeEcho Denotes whether to return created appointment in the response
+     * @param maxSize Maximum inline length
+     * @param includeHtml Denotes whether to include html in response echo
+     * @param doNeuter Denotes whether to neuter elements of the echo (e.g. images)
+     * @param doForce Denotes whether to force send the messag
+     * @param message Message
+     * @return Modify appointment response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public ModifyAppointmentResponse appointmentModify(RequestContext rctxt, String id,
+        Integer componentNumber, Integer modifiedSequence, Integer revision, Boolean includeEcho,
+        Integer maxSize, Boolean includeHtml, Boolean doNeuter, Boolean doForce, Msg message)
+        throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final ModifyAppointmentRequest request = new ModifyAppointmentRequest();
+        request.setId(id);
+        request.setComponentNum(componentNumber);
+        request.setEcho(includeEcho);
+        request.setModifiedSequence(modifiedSequence);
+        request.setRevision(revision);
+        request.setMaxSize(maxSize);
+        request.setWantHtml(includeHtml);
+        request.setNeuter(doNeuter);
+        request.setForceSend(doForce);
+        request.setMsg(message);
+        final Element response = XMLDocumentUtilities.executeDocument(
+            modifyAppointmentHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
+        ModifyAppointmentResponse resp = null;
+        if (response != null) {
+            resp = XMLDocumentUtilities.fromElement(response,
+                ModifyAppointmentResponse.class);
+        }
+        return resp;
+    }
+
+    /**
+     * Replies to an invite.
+     *
+     * @param rctxt The request context
+     * @param id Invite ID of default invite
+     * @param componentNumber Component number of default invite
+     * @param verb Invite action
+     * @param doUpdateOrganizer Denotes whether to update the organizer
+     * @param identityId Identity id to use to send reply
+     * @param exceptionId If supplied then reply to a single instance of the specified Invite (default is all)
+     * @param timezone Definition for TZID reference by datetime in instance
+     * @param message Message
+     * @return Send invite reply response
+     * @throws ServiceException If there are issues executing the document
+     */
+    public SendInviteReplyResponse inviteReply(RequestContext rctxt, String id,
+        Integer componentNumber, GQLInviteReplyVerbInput verb, Boolean doUpdateOrganizer,
+        String identityId, DtTimeInfo exceptionId, CalTZInfo timezone, Msg message)
+        throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final SendInviteReplyRequest request = new SendInviteReplyRequest(id, componentNumber, verb.name());
+        request.setUpdateOrganizer(doUpdateOrganizer);
+        request.setIdentityId(identityId);
+        request.setExceptionId(exceptionId);
+        request.setTimezone(timezone);
+        request.setMsg(message);
+        final Element response = XMLDocumentUtilities.executeDocument(
+            inviteReplyHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
+        SendInviteReplyResponse resp = null;
+        if (response != null) {
+            resp = XMLDocumentUtilities.fromElement(response,
+                SendInviteReplyResponse.class);
+        }
+        return resp;
+    }
+
+    /**
+     * Cancels an appointment.
+     *
+     * @param rctxt The request context
+     * @param id Invite ID of default invite
+     * @param componentNumber Component number of default invite
+     * @param modifiedSequence Change sequence of fetched version. Used for conflict detection
+     * @param revision Revision
+     * @param instance Instance recurrence ID information
+     * @param timezone Definition for TZID reference by datetime in instance
+     * @param message Message
+     * @return True if successful
+     * @throws ServiceException If there are issues executing the document
+     */
+    public Boolean appointmentCancel(RequestContext rctxt, String id,
+        Integer componentNumber, Integer modifiedSequence, Integer revision,
+        InstanceRecurIdInfo instance, CalTZInfo timezone, Msg message)
+        throws ServiceException {
+        final ZimbraSoapContext zsc = GQLAuthUtilities.getZimbraSoapContext(rctxt);
+        final CancelAppointmentRequest request = new CancelAppointmentRequest();
+        request.setId(id);
+        request.setComponentNum(componentNumber);
+        request.setModifiedSequence(modifiedSequence);
+        request.setRevision(revision);
+        request.setInstance(instance);
+        request.setTimezone(timezone);
+        request.setMsg(message);
+        XMLDocumentUtilities.executeDocument(
+            cancelAppointmentHandler,
+            zsc,
+            XMLDocumentUtilities.toElement(request),
+            rctxt);
+        return true;
+    }
+
+}

--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLCalendarRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLCalendarRepository.java
@@ -16,6 +16,8 @@
  */
 package com.zimbra.graphql.repositories.impl;
 
+import org.dom4j.QName;
+
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.service.mail.CancelAppointment;
@@ -105,6 +107,12 @@ public class ZXMLCalendarRepository extends ZXMLRepository implements IRepositor
         this.modifyAppointmentHandler = modifyAppointmentHandler;
         this.cancelAppointmentHandler = cancelAppointmentHandler;
         this.inviteReplyHandler = inviteReplyHandler;
+        // set response models
+        this.createAppointmentHandler.setResponseQName(QName.get("CreateAppointmentResponse"));
+        this.createAppointmentExceptionHandler.setResponseQName(QName.get("CreateAppointmentExceptionResponse"));
+        this.modifyAppointmentHandler.setResponseQName(QName.get("ModifyAppointmentResponse"));
+        this.cancelAppointmentHandler.setResponseQName(QName.get("CancelAppointmentResponse"));
+        this.inviteReplyHandler.setResponseQName(QName.get("SendInviteReplyResponse"));
     }
 
     /**

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -149,4 +149,5 @@ public class AccountResolver {
         @GraphQLRootContext RequestContext context) throws ServiceException {
         return accountRepository.signatureDelete(context, identifier);
     }
+
 }

--- a/src/java/com/zimbra/graphql/resolvers/impl/CalendarResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/CalendarResolver.java
@@ -1,0 +1,124 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2018 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resolvers.impl;
+
+import com.zimbra.common.gql.GqlConstants;
+import com.zimbra.common.service.ServiceException;
+import com.zimbra.graphql.models.RequestContext;
+import com.zimbra.graphql.models.inputs.GQLInviteReplyVerbInput;
+import com.zimbra.graphql.repositories.impl.ZXMLCalendarRepository;
+import com.zimbra.soap.mail.message.CreateAppointmentExceptionResponse;
+import com.zimbra.soap.mail.message.CreateAppointmentResponse;
+import com.zimbra.soap.mail.message.ModifyAppointmentResponse;
+import com.zimbra.soap.mail.message.SendInviteReplyResponse;
+import com.zimbra.soap.mail.type.CalTZInfo;
+import com.zimbra.soap.mail.type.DtTimeInfo;
+import com.zimbra.soap.mail.type.InstanceRecurIdInfo;
+import com.zimbra.soap.mail.type.Msg;
+
+import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.annotations.GraphQLNonNull;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+
+/**
+ * The CalendarResolver class.<br>
+ * Contains calendar schema resources.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.resolvers.impl
+ * @copyright Copyright © 2018
+ */
+public class CalendarResolver {
+
+    protected ZXMLCalendarRepository calendarRepository = null;
+
+    /**
+     * Creates an instance with specified calendar repository.
+     *
+     * @param calendarRepository The calendar repository
+     */
+    public CalendarResolver(ZXMLCalendarRepository calendarRepository) {
+        this.calendarRepository = calendarRepository;
+    }
+
+    @GraphQLMutation(description="Create an appointment")
+    public CreateAppointmentResponse appointmentCreate(@GraphQLArgument(name=GqlConstants.INCLUDE_ECHO, description="Denotes whether to return created appointment in the response") Boolean includeEcho,
+        @GraphQLArgument(name=GqlConstants.MAX_SIZE, description="Maximum inline length") Integer maxSize,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_HTML, description="Denotes whether to include html in response echo") Boolean includeHtml,
+        @GraphQLArgument(name=GqlConstants.DO_NEUTER, description="Denotes whether to neuter elements of the echo (e.g. images)") Boolean doNeuter,
+        @GraphQLArgument(name=GqlConstants.DO_FORCE, description="Denotes whether to force send the message") Boolean doForce,
+        @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
+        @GraphQLRootContext RequestContext rctxt) throws ServiceException {
+        return calendarRepository.appointmentCreate(rctxt, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
+    }
+
+    @GraphQLMutation(description="Create an appointment exception")
+    public CreateAppointmentExceptionResponse appointmentExceptionCreate(@GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
+        @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of default component") Integer componentNumber,
+        @GraphQLArgument(name=GqlConstants.MODIFIED_SEQUENCE, description="Change sequence of fetched version. Used for conflict detection") Integer modifiedSequence,
+        @GraphQLArgument(name=GqlConstants.REVISION, description="Revision") Integer revision,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_ECHO, description="Denotes whether to return created appointment in the response") Boolean includeEcho,
+        @GraphQLArgument(name=GqlConstants.MAX_SIZE, description="Maximum inline length") Integer maxSize,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_HTML, description="Denotes whether to include html in response echo") Boolean includeHtml,
+        @GraphQLArgument(name=GqlConstants.DO_NEUTER, description="Denotes whether to neuter elements of the echo (e.g. images)") Boolean doNeuter,
+        @GraphQLArgument(name=GqlConstants.DO_FORCE, description="Denotes whether to force send the message") Boolean doForce,
+        @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
+        @GraphQLRootContext RequestContext rctxt) throws ServiceException {
+        return calendarRepository.appointmentExceptionCreate(rctxt, id, componentNumber, modifiedSequence, revision, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
+    }
+
+    @GraphQLMutation(description="Modify an appointment")
+    public ModifyAppointmentResponse appointmentModify(@GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
+        @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of default component") Integer componentNumber,
+        @GraphQLArgument(name=GqlConstants.MODIFIED_SEQUENCE, description="Change sequence of fetched version. Used for conflict detection.") Integer modifiedSequence,
+        @GraphQLArgument(name=GqlConstants.REVISION, description="Revision") Integer revision,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_ECHO, description="Denotes whether to return created appointment in the response") Boolean includeEcho,
+        @GraphQLArgument(name=GqlConstants.MAX_SIZE, description="Maximum inline length") Integer maxSize,
+        @GraphQLArgument(name=GqlConstants.INCLUDE_HTML, description="Denotes whether to include html in response echo") Boolean includeHtml,
+        @GraphQLArgument(name=GqlConstants.DO_NEUTER, description="Denotes whether to neuter elements of the echo (e.g. images)") Boolean doNeuter,
+        @GraphQLArgument(name=GqlConstants.DO_FORCE, description="Denotes whether to force send the message") Boolean doForce,
+        @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
+        @GraphQLRootContext RequestContext rctxt) throws ServiceException {
+        return calendarRepository.appointmentModify(rctxt, id, componentNumber, modifiedSequence, revision, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
+    }
+
+    @GraphQLMutation(description="Reply to an invite")
+    public SendInviteReplyResponse inviteReply(@GraphQLNonNull @GraphQLArgument(name=GqlConstants.ID, description="ID of invite to reply to") String id,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of the invite") Integer componentNumber,
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.VERB, description="Invite action") GQLInviteReplyVerbInput verb,
+        @GraphQLArgument(name=GqlConstants.DO_UPDATE_ORGANIZER, description="Denotes whether to update the organizer", defaultValue="true") Boolean doUpdateOrganizer,
+        @GraphQLArgument(name=GqlConstants.IDENTITY_ID, description="Identity id to use to send reply") String identityId,
+        @GraphQLArgument(name=GqlConstants.EXCEPTION_ID, description="If supplied then reply to a single instance of the specified Invite (default is all)") DtTimeInfo exceptionId,
+        @GraphQLArgument(name=GqlConstants.TIMEZONE, description="Definition for TZID reference by datetime in exceptionId") CalTZInfo timezone,
+        @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
+        @GraphQLRootContext RequestContext rctxt) throws ServiceException {
+        return calendarRepository.inviteReply(rctxt, id, componentNumber, verb, doUpdateOrganizer, identityId, exceptionId, timezone, message);
+    }
+
+    @GraphQLMutation(description="Cancel an appointment")
+    public Boolean appointmentCancel(@GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
+        @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of default component") Integer componentNumber,
+        @GraphQLArgument(name=GqlConstants.MODIFIED_SEQUENCE, description="Change sequence of fetched version. Used for conflict detection.") Integer modifiedSequence,
+        @GraphQLArgument(name=GqlConstants.REVISION, description="Revision") Integer revision,
+        @GraphQLArgument(name=GqlConstants.INSTANCE, description="Instance recurrence ID information") InstanceRecurIdInfo instance,
+        @GraphQLArgument(name=GqlConstants.TIMEZONE, description="Definition for TZID reference by datetime in instance") CalTZInfo timezone,
+        @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
+        @GraphQLRootContext RequestContext rctxt) throws ServiceException {
+        return calendarRepository.appointmentCancel(rctxt, id, componentNumber, modifiedSequence, revision, instance, timezone, message);
+    }
+}

--- a/src/java/com/zimbra/graphql/resolvers/impl/CalendarResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/CalendarResolver.java
@@ -57,18 +57,21 @@ public class CalendarResolver {
     }
 
     @GraphQLMutation(description="Create an appointment")
-    public CreateAppointmentResponse appointmentCreate(@GraphQLArgument(name=GqlConstants.INCLUDE_ECHO, description="Denotes whether to return created appointment in the response") Boolean includeEcho,
+    public CreateAppointmentResponse appointmentCreate(
+        @GraphQLArgument(name=GqlConstants.INCLUDE_ECHO, description="Denotes whether to return created appointment in the response") Boolean includeEcho,
         @GraphQLArgument(name=GqlConstants.MAX_SIZE, description="Maximum inline length") Integer maxSize,
         @GraphQLArgument(name=GqlConstants.INCLUDE_HTML, description="Denotes whether to include html in response echo") Boolean includeHtml,
         @GraphQLArgument(name=GqlConstants.DO_NEUTER, description="Denotes whether to neuter elements of the echo (e.g. images)") Boolean doNeuter,
         @GraphQLArgument(name=GqlConstants.DO_FORCE, description="Denotes whether to force send the message") Boolean doForce,
         @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
         @GraphQLRootContext RequestContext rctxt) throws ServiceException {
-        return calendarRepository.appointmentCreate(rctxt, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
+        return calendarRepository.appointmentCreate(rctxt, includeEcho, maxSize, includeHtml,
+            doNeuter, doForce, message);
     }
 
     @GraphQLMutation(description="Create an appointment exception")
-    public CreateAppointmentExceptionResponse appointmentExceptionCreate(@GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
+    public CreateAppointmentExceptionResponse appointmentExceptionCreate(
+        @GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
         @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of default component") Integer componentNumber,
         @GraphQLArgument(name=GqlConstants.MODIFIED_SEQUENCE, description="Change sequence of fetched version. Used for conflict detection") Integer modifiedSequence,
         @GraphQLArgument(name=GqlConstants.REVISION, description="Revision") Integer revision,
@@ -79,11 +82,14 @@ public class CalendarResolver {
         @GraphQLArgument(name=GqlConstants.DO_FORCE, description="Denotes whether to force send the message") Boolean doForce,
         @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
         @GraphQLRootContext RequestContext rctxt) throws ServiceException {
-        return calendarRepository.appointmentExceptionCreate(rctxt, id, componentNumber, modifiedSequence, revision, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
+        return calendarRepository.appointmentExceptionCreate(rctxt, id, componentNumber,
+            modifiedSequence, revision, includeEcho, maxSize, includeHtml, doNeuter, doForce,
+            message);
     }
 
     @GraphQLMutation(description="Modify an appointment")
-    public ModifyAppointmentResponse appointmentModify(@GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
+    public ModifyAppointmentResponse appointmentModify(
+        @GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
         @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of default component") Integer componentNumber,
         @GraphQLArgument(name=GqlConstants.MODIFIED_SEQUENCE, description="Change sequence of fetched version. Used for conflict detection.") Integer modifiedSequence,
         @GraphQLArgument(name=GqlConstants.REVISION, description="Revision") Integer revision,
@@ -94,11 +100,13 @@ public class CalendarResolver {
         @GraphQLArgument(name=GqlConstants.DO_FORCE, description="Denotes whether to force send the message") Boolean doForce,
         @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
         @GraphQLRootContext RequestContext rctxt) throws ServiceException {
-        return calendarRepository.appointmentModify(rctxt, id, componentNumber, modifiedSequence, revision, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
+        return calendarRepository.appointmentModify(rctxt, id, componentNumber, modifiedSequence,
+            revision, includeEcho, maxSize, includeHtml, doNeuter, doForce, message);
     }
 
     @GraphQLMutation(description="Reply to an invite")
-    public SendInviteReplyResponse inviteReply(@GraphQLNonNull @GraphQLArgument(name=GqlConstants.ID, description="ID of invite to reply to") String id,
+    public SendInviteReplyResponse inviteReply(
+        @GraphQLNonNull @GraphQLArgument(name=GqlConstants.ID, description="ID of invite to reply to") String id,
         @GraphQLNonNull @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of the invite") Integer componentNumber,
         @GraphQLNonNull @GraphQLArgument(name=GqlConstants.VERB, description="Invite action") GQLInviteReplyVerbInput verb,
         @GraphQLArgument(name=GqlConstants.DO_UPDATE_ORGANIZER, description="Denotes whether to update the organizer", defaultValue="true") Boolean doUpdateOrganizer,
@@ -107,11 +115,13 @@ public class CalendarResolver {
         @GraphQLArgument(name=GqlConstants.TIMEZONE, description="Definition for TZID reference by datetime in exceptionId") CalTZInfo timezone,
         @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
         @GraphQLRootContext RequestContext rctxt) throws ServiceException {
-        return calendarRepository.inviteReply(rctxt, id, componentNumber, verb, doUpdateOrganizer, identityId, exceptionId, timezone, message);
+        return calendarRepository.inviteReply(rctxt, id, componentNumber, verb, doUpdateOrganizer,
+            identityId, exceptionId, timezone, message);
     }
 
     @GraphQLMutation(description="Cancel an appointment")
-    public Boolean appointmentCancel(@GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
+    public Boolean appointmentCancel(
+        @GraphQLArgument(name=GqlConstants.ID, description="Invite ID of default invite") String id,
         @GraphQLArgument(name=GqlConstants.COMPONENT_NUMBER, description="Component number of default component") Integer componentNumber,
         @GraphQLArgument(name=GqlConstants.MODIFIED_SEQUENCE, description="Change sequence of fetched version. Used for conflict detection.") Integer modifiedSequence,
         @GraphQLArgument(name=GqlConstants.REVISION, description="Revision") Integer revision,
@@ -119,6 +129,7 @@ public class CalendarResolver {
         @GraphQLArgument(name=GqlConstants.TIMEZONE, description="Definition for TZID reference by datetime in instance") CalTZInfo timezone,
         @GraphQLArgument(name=GqlConstants.MESSAGE, description="Message") Msg message,
         @GraphQLRootContext RequestContext rctxt) throws ServiceException {
-        return calendarRepository.appointmentCancel(rctxt, id, componentNumber, modifiedSequence, revision, instance, timezone, message);
+        return calendarRepository.appointmentCancel(rctxt, id, componentNumber, modifiedSequence,
+            revision, instance, timezone, message);
     }
 }

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -38,12 +38,14 @@ import com.zimbra.graphql.errors.GQLError;
 import com.zimbra.graphql.repositories.impl.ZNativeAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLCalendarRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLMessageRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
 import com.zimbra.graphql.resolvers.impl.AccountResolver;
 import com.zimbra.graphql.resolvers.impl.AuthResolver;
+import com.zimbra.graphql.resolvers.impl.CalendarResolver;
 import com.zimbra.graphql.resolvers.impl.ContactResolver;
 import com.zimbra.graphql.resolvers.impl.FolderResolver;
 import com.zimbra.graphql.resolvers.impl.MessageResolver;
@@ -230,6 +232,7 @@ public class GQLServlet extends ExtensionHttpHandler {
     protected GraphQLSchema buildSchema() {
         final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
         final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository(), new ZNativeAuthRepository());
+        final CalendarResolver calendarResolver = new CalendarResolver(new ZXMLCalendarRepository());
         final ContactResolver contactResolver = new ContactResolver(new ZXMLContactRepository());
         final FolderResolver folderResolver = new FolderResolver(new ZXMLFolderRepository());
         final MessageResolver messageResolver = new MessageResolver(new ZXMLMessageRepository());
@@ -242,6 +245,7 @@ public class GQLServlet extends ExtensionHttpHandler {
             .withOperationsFromSingletons(
                 accountResolver,
                 authResolver,
+                calendarResolver,
                 contactResolver,
                 folderResolver,
                 messageResolver,


### PR DESCRIPTION
* Added calendar resolver and repository with support for the mutations specified on the jira ticket (create, create exception, modify, cancel, send invite reply).
* Have to set response elements on the document handlers since they're not registered by QName properly with the document dispatcher (not sure why this is, still looking).

See associated PR:
Zimbra/zm-mailbox#825

Looking for feedback on temporary interface workaround for the recurrence rules (basically ignore the interface and split it into each subclass until we can upgrade for type resolution of the base class):
https://github.com/Zimbra/zm-mailbox/compare/bugfix/ZCS-6138#diff-50358bcac0febf84b91be062ed80b138R45


**Testing done**
Creating, modifying, canceling, replying to simple appointments so far, working through with QA.

**Testing to be done by QA**
Everything...