### PR TITLE
ZCS-6452 Implement schema builder

### DIFF
--- a/src/java-test/com/zimbra/graphql/resources/GQLSchemaBuilderTest.java
+++ b/src/java-test/com/zimbra/graphql/resources/GQLSchemaBuilderTest.java
@@ -1,0 +1,57 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resources;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+/**
+ * Test class for {@link GQLSchemaBuilder}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({GQLSchemaBuilder.class})
+public class GQLSchemaBuilderTest {
+
+    /**
+     * Test method for {@link GQLSchemaBuilder#newInstance}<br>
+     * Validates that at least the standard schema builder is loaded.
+     *
+     * @throws Exception If there are issues testing
+     */
+    @Test
+    public void testNewInstanceStandard() throws Exception {
+        PowerMock.mockStaticPartial(
+            GQLSchemaBuilder.class, "loadBuilder");
+
+        GQLSchemaBuilder.loadBuilder();
+        PowerMock.expectLastCall().andReturn(null);
+
+        PowerMock.replay(GQLSchemaBuilder.class);
+
+        final GQLSchemaBuilder builder = GQLSchemaBuilder.newInstance();
+        assertNotNull(builder);
+
+        PowerMock.verify(GQLSchemaBuilder.class);
+    }
+
+}

--- a/src/java/com/zimbra/graphql/resolvers/IResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/IResolver.java
@@ -1,0 +1,29 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.resolvers;
+
+/**
+ * The IResolver interface.<br>
+ * Interface for all graphql resolvers.
+ *
+ * @author Zimbra API Team
+ * @package com.zimbra.graphql.resolvers
+ * @copyright Copyright © 2019
+ */
+public interface IResolver {
+
+}

--- a/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AccountResolver.java
@@ -25,6 +25,7 @@ import com.zimbra.graphql.models.inputs.GQLPrefInput;
 import com.zimbra.graphql.models.outputs.AccountInfo;
 import com.zimbra.graphql.models.outputs.GQLWhiteBlackListResponse;
 import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.account.message.ChangePasswordResponse;
 import com.zimbra.soap.account.message.GetInfoResponse;
 import com.zimbra.soap.account.type.NameId;
@@ -47,7 +48,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @package com.zimbra.graphql.resolvers.impl
  * @copyright Copyright © 2018
  */
-public class AccountResolver {
+public class AccountResolver implements IResolver {
 
     protected ZXMLAccountRepository accountRepository = null;
 

--- a/src/java/com/zimbra/graphql/resolvers/impl/AuthResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/AuthResolver.java
@@ -24,6 +24,7 @@ import com.zimbra.graphql.models.inputs.GQLAuthRequestInput;
 import com.zimbra.graphql.models.outputs.GQLSessionInfo;
 import com.zimbra.graphql.repositories.impl.ZNativeAuthRepository;
 import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.account.message.AuthResponse;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
@@ -40,7 +41,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @package com.zimbra.graphql.resolvers.impl
  * @copyright Copyright © 2018
  */
-public class AuthResolver {
+public class AuthResolver implements IResolver {
 
     protected ZXMLAuthRepository xmlAuthRepository = null;
     protected ZNativeAuthRepository nativeAuthRepository = null;

--- a/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/ContactResolver.java
@@ -23,6 +23,7 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLGetContactsRequestInput;
 import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.mail.type.ActionResult;
 import com.zimbra.soap.mail.type.ContactInfo;
 import com.zimbra.soap.mail.type.ContactSpec;
@@ -44,7 +45,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @package com.zimbra.graphql.resolvers.impl
  * @copyright Copyright © 2018
  */
-public class ContactResolver {
+public class ContactResolver implements IResolver {
 
     protected ZXMLContactRepository contactRepository = null;
 

--- a/src/java/com/zimbra/graphql/resolvers/impl/FolderResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/FolderResolver.java
@@ -24,6 +24,7 @@ import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.models.inputs.GQLFolderSelector;
 import com.zimbra.graphql.models.inputs.GQLOwnerSelector;
 import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.mail.type.Folder;
 import com.zimbra.soap.mail.type.FolderActionResult;
 import com.zimbra.soap.mail.type.FolderActionSelector;
@@ -51,7 +52,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @package com.zimbra.graphql.resolvers.impl
  * @copyright Copyright © 2018
  */
-public class FolderResolver {
+public class FolderResolver implements IResolver {
 
     protected ZXMLFolderRepository folderRepository = null;
 

--- a/src/java/com/zimbra/graphql/resolvers/impl/MessageResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/MessageResolver.java
@@ -22,6 +22,7 @@ import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.repositories.impl.ZXMLMessageRepository;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.mail.message.SendShareNotificationRequest.Action;
 import com.zimbra.soap.mail.type.EmailAddrInfo;
 import com.zimbra.soap.mail.type.Msg;
@@ -42,7 +43,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @author Zimbra API Team
  * @package com.zimbra.graphql.resolvers.impl
  */
-public class MessageResolver {
+public class MessageResolver implements IResolver {
 
     protected ZXMLMessageRepository messageRepository = null;
 
@@ -70,7 +71,7 @@ public class MessageResolver {
         @GraphQLArgument(name = GqlConstants.SEND_UID, description = "Send UID.") String sendUid,
         @GraphQLArgument(name = GqlConstants.MESSAGE, description = "The message to send.") MsgToSend message,
         @GraphQLRootContext RequestContext context) throws ServiceException {
-        // TODO: False must be changed to Boolean isCalendarForward when isCalendarForward and invites are enabled 
+        // TODO: False must be changed to Boolean isCalendarForward when isCalendarForward and invites are enabled
         return messageRepository.messageSend(context, addSentBy, false, doSkipSave,
             doFetchSaved, sendUid, message);
     }

--- a/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/SearchResolver.java
@@ -28,6 +28,7 @@ import com.zimbra.graphql.models.outputs.GQLConversationSearchResponse;
 import com.zimbra.graphql.models.outputs.GQLMessageSearchResponse;
 import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
 import com.zimbra.soap.account.message.SearchGalResponse;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.type.GalSearchType;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
@@ -43,7 +44,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @package com.zimbra.graphql.resolvers.impl
  * @copyright Copyright © 2018
  */
-public class SearchResolver {
+public class SearchResolver implements IResolver {
 
     protected ZXMLSearchRepository searchRepository = null;
 

--- a/src/java/com/zimbra/graphql/resolvers/impl/TaskResolver.java
+++ b/src/java/com/zimbra/graphql/resolvers/impl/TaskResolver.java
@@ -20,6 +20,7 @@ import com.zimbra.common.gql.GqlConstants;
 import com.zimbra.common.service.ServiceException;
 import com.zimbra.graphql.models.RequestContext;
 import com.zimbra.graphql.repositories.impl.ZXMLTaskRepository;
+import com.zimbra.graphql.resolvers.IResolver;
 import com.zimbra.soap.mail.message.CreateTaskExceptionResponse;
 import com.zimbra.soap.mail.message.CreateTaskResponse;
 import com.zimbra.soap.mail.message.ModifyTaskResponse;
@@ -40,7 +41,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
  * @package com.zimbra.graphql.resolvers.impl
  * @copyright Copyright © 2019
  */
-public class TaskResolver {
+public class TaskResolver implements IResolver {
 
     protected ZXMLTaskRepository taskRepository = null;
 

--- a/src/java/com/zimbra/graphql/resources/GQLSchemaBuilder.java
+++ b/src/java/com/zimbra/graphql/resources/GQLSchemaBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra GraphQL Extension
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */package com.zimbra.graphql.resources;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.graphql.repositories.impl.ZNativeAuthRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLMessageRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
+import com.zimbra.graphql.repositories.impl.ZXMLTaskRepository;
+import com.zimbra.graphql.resolvers.IResolver;
+import com.zimbra.graphql.resolvers.impl.AccountResolver;
+import com.zimbra.graphql.resolvers.impl.AuthResolver;
+import com.zimbra.graphql.resolvers.impl.ContactResolver;
+import com.zimbra.graphql.resolvers.impl.FolderResolver;
+import com.zimbra.graphql.resolvers.impl.MessageResolver;
+import com.zimbra.graphql.resolvers.impl.SearchResolver;
+import com.zimbra.graphql.resolvers.impl.TaskResolver;
+
+import graphql.schema.GraphQLSchema;
+import io.leangen.graphql.GraphQLSchemaGenerator;
+
+/**
+  * GQLSchemaBuilder class.<br>
+  * Contains methods for loading and building the graphql schema.
+  *
+  * @author Zimbra API Team
+  * @package com.zimbra.graphql.resources
+  * @copyright Copyright © 2019
+  */
+public class GQLSchemaBuilder {
+
+    /**
+     * List of query and mutation resolvers to build schema with.
+     */
+    protected List<IResolver> resolvers = new ArrayList<IResolver>();
+
+    /**
+     * Add all resolvers that represent schema queries and mutations.
+     *
+     * @return This instance
+     */
+    protected GQLSchemaBuilder loadResolvers() {
+        resolvers.add(new AccountResolver(new ZXMLAccountRepository()));
+        resolvers.add(new AuthResolver(new ZXMLAuthRepository(), new ZNativeAuthRepository()));
+        resolvers.add(new ContactResolver(new ZXMLContactRepository()));
+        resolvers.add(new FolderResolver(new ZXMLFolderRepository()));
+        resolvers.add(new MessageResolver(new ZXMLMessageRepository()));
+        resolvers.add(new SearchResolver(new ZXMLSearchRepository()));
+        resolvers.add(new TaskResolver(new ZXMLTaskRepository()));
+        return this;
+    }
+
+    /**
+     * Creates the schema with loaded resolvers.
+     *
+     * @return A graphql schema
+     */
+    public GraphQLSchema build() {
+        loadResolvers();
+        ZimbraLog.extensions.info("Generating schema with loaded resolvers . . .");
+        return new GraphQLSchemaGenerator()
+            .withBasePackages(
+                "com.zimbra.graphql.models",
+                "com.zimbra.soap")
+            .withOperationsFromSingletons(
+                resolvers.toArray()
+            ).generate();
+    }
+
+    /**
+     * Creates an instance of the schema builder.<br>
+     * Use network schema builder, default to standard if not available.
+     *
+     * @return An instance of the schema builder
+     */
+    public static GQLSchemaBuilder newInstance() {
+        // check for network edition builder
+        GQLSchemaBuilder builder = loadBuilder();
+        if (builder == null) {
+            // use standard as default
+            ZimbraLog.extensions.info("Loading standard graphql schema builder.");
+            builder = new GQLSchemaBuilder();
+        }
+        return builder;
+    }
+
+    /**
+     * Attempts to load network schema builder.<br>
+     * Returns null if unavailable.
+     *
+     * @return GQLSchemaBuilder or null if network edition is unavailable
+     */
+    protected static GQLSchemaBuilder loadBuilder() {
+        try {
+            ZimbraLog.extensions.debug("Looking for %s.", "GQLNetworkSchemaBuilder");
+            final Class<?> schemaClass = Class.forName(
+                GQLSchemaBuilder.class.getPackage().getName() + ".GQLNetworkSchemaBuilder");
+            ZimbraLog.extensions.info("Loading network edition graphql schema builder.");
+            return (GQLSchemaBuilder) schemaClass.getConstructor().newInstance();
+        } catch (final ClassNotFoundException e) {
+            // do nothing if network edition isn't in path
+        } catch (InstantiationException | IllegalAccessException
+            | IllegalArgumentException | InvocationTargetException
+            | NoSuchMethodException | SecurityException e) {
+            ZimbraLog.extensions.errorQuietly(
+                "There was an issue instantiating the network edition graphql schema builder.", e);
+        }
+
+        return null;
+    }
+}

--- a/src/java/com/zimbra/graphql/resources/GQLServlet.java
+++ b/src/java/com/zimbra/graphql/resources/GQLServlet.java
@@ -35,23 +35,6 @@ import com.zimbra.common.service.ServiceException;
 import com.zimbra.common.util.ZimbraLog;
 import com.zimbra.cs.extension.ExtensionHttpHandler;
 import com.zimbra.graphql.errors.GQLError;
-import com.zimbra.graphql.repositories.impl.ZNativeAuthRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLAccountRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLAuthRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLCalendarRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLContactRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLFolderRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLMessageRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLSearchRepository;
-import com.zimbra.graphql.repositories.impl.ZXMLTaskRepository;
-import com.zimbra.graphql.resolvers.impl.AccountResolver;
-import com.zimbra.graphql.resolvers.impl.AuthResolver;
-import com.zimbra.graphql.resolvers.impl.CalendarResolver;
-import com.zimbra.graphql.resolvers.impl.ContactResolver;
-import com.zimbra.graphql.resolvers.impl.FolderResolver;
-import com.zimbra.graphql.resolvers.impl.MessageResolver;
-import com.zimbra.graphql.resolvers.impl.SearchResolver;
-import com.zimbra.graphql.resolvers.impl.TaskResolver;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
 import com.zimbra.graphql.utilities.GQLConstants;
 import com.zimbra.graphql.utilities.GQLUtilities;
@@ -61,8 +44,6 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.GraphqlErrorHelper;
 import graphql.execution.UnknownOperationException;
-import graphql.schema.GraphQLSchema;
-import io.leangen.graphql.GraphQLSchemaGenerator;
 
 /**
  * The GQLServlet class.<br>
@@ -88,7 +69,7 @@ public class GQLServlet extends ExtensionHttpHandler {
      * Constructs an instance and sets up gql object with schema.
      */
     public GQLServlet() {
-        graphql = GraphQL.newGraphQL(buildSchema())
+        graphql = GraphQL.newGraphQL(GQLSchemaBuilder.newInstance().build())
             .build();
     }
 
@@ -224,37 +205,6 @@ public class GQLServlet extends ExtensionHttpHandler {
         ZimbraLog.extensions.debug("Writing http response.");
         resp.getWriter().print(mapper.writeValueAsString(result));
         resp.getWriter().flush();
-    }
-
-    /**
-     * Wires the application schema given resolvers.
-     *
-     * @return A wired schema
-     */
-    protected GraphQLSchema buildSchema() {
-        final AccountResolver accountResolver = new AccountResolver(new ZXMLAccountRepository());
-        final AuthResolver authResolver = new AuthResolver(new ZXMLAuthRepository(), new ZNativeAuthRepository());
-        final CalendarResolver calendarResolver = new CalendarResolver(new ZXMLCalendarRepository());
-        final TaskResolver taskResolver = new TaskResolver(new ZXMLTaskRepository());
-        final ContactResolver contactResolver = new ContactResolver(new ZXMLContactRepository());
-        final FolderResolver folderResolver = new FolderResolver(new ZXMLFolderRepository());
-        final MessageResolver messageResolver = new MessageResolver(new ZXMLMessageRepository());
-        final SearchResolver searchResolver = new SearchResolver(new ZXMLSearchRepository());
-        ZimbraLog.extensions.info("Generating schema with loaded resolvers . . .");
-        return new GraphQLSchemaGenerator()
-            .withBasePackages(
-                "com.zimbra.graphql.models",
-                "com.zimbra.soap")
-            .withOperationsFromSingletons(
-                accountResolver,
-                authResolver,
-                calendarResolver,
-                taskResolver,
-                contactResolver,
-                folderResolver,
-                messageResolver,
-                searchResolver
-            ).generate();
     }
 
     /**


### PR DESCRIPTION
* Added schema builder to ease zm-network-gql's required files to override schema build
  * May consider a loading strategy for the new builder instance if we intend to have multiple overloading projects beyond zm-network-gql
* Originally implemented `HandlerManager` setup from @chinmay15's ZCS-4586 branch throughout all repositories and tests, but moved it to a separate branch due to time constraints.

See associated PR:
Zimbra/zm-network-gql#1