### PR TITLE
ZCS-4586 Implement License (account info) to the AccountInfoRepository class

### DIFF
--- a/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
+++ b/src/java/com/zimbra/graphql/repositories/impl/ZXMLAccountRepository.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 
 import com.zimbra.common.service.ServiceException;
+import com.zimbra.common.soap.AccountConstants;
 import com.zimbra.common.soap.Element;
 import com.zimbra.cs.service.account.ChangePassword;
 import com.zimbra.cs.service.account.CreateSignature;
@@ -41,6 +42,7 @@ import com.zimbra.graphql.models.outputs.AccountInfo;
 import com.zimbra.graphql.models.outputs.GQLWhiteBlackListResponse;
 import com.zimbra.graphql.repositories.IRepository;
 import com.zimbra.graphql.utilities.GQLAuthUtilities;
+import com.zimbra.graphql.utilities.HandlerManager;
 import com.zimbra.graphql.utilities.XMLDocumentUtilities;
 import com.zimbra.soap.ZimbraSoapContext;
 import com.zimbra.soap.account.message.ChangePasswordRequest;
@@ -98,11 +100,6 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
      * Modify perfs document handler.
      */
     private final ModifyPrefs modifyPrefsHandler;
-
-    /**
-     * GetInfo document handler.
-     */
-    private final GetInfo infoHandler;
 
     /**
      * Change password document handler.
@@ -175,7 +172,7 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
         this.endSessionHandler = endSessionHandler;
         this.prefsHandler = prefsHandler;
         this.modifyPrefsHandler = modifyPrefsHandler;
-        this.infoHandler = infoHandler;
+        HandlerManager.registerHandler(AccountConstants.GET_INFO_REQUEST, infoHandler);
         this.changePasswordHandler = changePasswordHandler;
         this.getWhiteBlackListHandler = getWhiteBlackListHandler;
         this.modifyWhiteBlackListHandler = modifyWhiteBlackListHandler;
@@ -204,7 +201,7 @@ public class ZXMLAccountRepository extends ZXMLRepository implements IRepository
             request.setRights(rights);
         }
         final Element response = XMLDocumentUtilities.executeDocument(
-                infoHandler,
+                HandlerManager.getHandler(AccountConstants.GET_INFO_REQUEST),
                 zsc,
                 XMLDocumentUtilities.toElement(request),
                 rctxt);

--- a/src/java/com/zimbra/graphql/utilities/HandlerManager.java
+++ b/src/java/com/zimbra/graphql/utilities/HandlerManager.java
@@ -1,0 +1,53 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Server
+ * Copyright (C) 2019 Synacor, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software Foundation,
+ * version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ * ***** END LICENSE BLOCK *****
+ */
+package com.zimbra.graphql.utilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.dom4j.QName;
+
+import com.zimbra.common.util.ZimbraLog;
+import com.zimbra.soap.DocumentHandler;
+
+public class HandlerManager {
+    private static Map<QName, DocumentHandler> handlers = new HashMap<QName, DocumentHandler>();
+
+    public static void registerHandler(QName qName, DocumentHandler handler) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Registering handle for ").append(qName.getName())
+            .append(" with ").append(handler.getClass().getName());
+        ZimbraLog.gql.debug(sb.toString());
+        handlers.put(qName, handler);
+    }
+
+    public static DocumentHandler getHandler(QName qName) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Getting handler for ").append(qName.getName());
+        ZimbraLog.gql.debug(sb.toString());
+        DocumentHandler handler = handlers.get(qName);
+        sb = new StringBuilder();
+        if (handler == null) {
+            sb.append("Handler not found for ").append(qName.getName());
+        } else {
+            sb.append("Found handler for ").append(qName.getName()).append(" : ")
+                .append(handler.getClass().getName());
+        }
+        ZimbraLog.gql.debug(sb.toString());
+        return handler;
+    }
+}


### PR DESCRIPTION
**Problem:** On ZCS network version, GetInfoRequest should return license block in response.

**Fix:**
- Implemented HandlerManager to register handlers in zm-gql.
- When zm-network-gql is deployed, it will register GetInfo handler from zm-license-store with HandlerManager and the GetInfoRequest is sent to GetInfo handler in zm-license-store.
- Updated ivy and build scripts in zm-network-gql

**Testing done:**
- Manually tested GetInfoRequest using graphiql client, which returns license block in the response when zm-network-gql is deployed.

**Testing to be done by QA:**
- Verify nothing is broken
- Validate GetInfoResponse with and without zm-network-gql

**Linked PR:**
https://github.com/Zimbra/zm-network-gql/pull/2