### PR TITLE
ZCS-8011: Third party vulnerabilities in Jackson databind

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -40,8 +40,8 @@
       <dependency org="org.json" name="json" rev="20090211" />
       <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.3.5.v20151012"/>
       <!-- jackson jars -->
-      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
Issue: Third-party vulnerabilities in Jackson library
Fix: Upgrade the Jackson library to the latest version

Related PRs:
https://github.com/Zimbra/zm-oauth-social/pull/54
https://github.com/Zimbra/zm-mailbox/pull/984
https://github.com/Zimbra/zm-zcs-lib/pull/59
https://github.com/Zimbra/zm-gql-admin/pull/1
https://github.com/Zimbra/zm-network-gql/pull/5