### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml 
+++ b/ivy.xml 
@@ -16,7 +16,7 @@
       <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
       <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.2" />
       <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5" />
-      <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
+      <dependency org="com.google.guava" name="guava" rev="23.0" />
       <!-- Local Requirements -->
       <dependency org="zimbra" name="zm-common" rev="latest.integration" />
       <dependency org="zimbra" name="zm-client" rev="latest.integration" />
@@ -40,8 +40,8 @@
       <dependency org="org.json" name="json" rev="20090211" />
       <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.3.5.v20151012"/>
       <!-- jackson jars -->
-      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
     </dependencies>
 </ivy-module>

--- a/ivy.xml-e
+++ b/ivy.xml-e
@@ -16,7 +16,7 @@
       <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
       <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.2" />
       <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5" />
-      <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
+      <dependency org="com.google.guava" name="guava" rev="23.0" />
       <!-- Local Requirements -->
       <dependency org="zimbra" name="zm-common" rev="latest.integration" />
       <dependency org="zimbra" name="zm-client" rev="latest.integration" />
@@ -40,8 +40,8 @@
       <dependency org="org.json" name="json" rev="20090211" />
       <dependency org="org.eclipse.jetty" name="jetty-continuation" rev="9.3.5.v20151012"/>
       <!-- jackson jars -->
-      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.9.2"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.9.2"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally