### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -16,7 +16,7 @@
       <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
       <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.2" />
       <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5" />
-      <dependency org="com.google.guava" name="guava" rev="23.0" />
+      <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
       <!-- Local Requirements -->
       <dependency org="zimbra" name="zm-common" rev="latest.integration" />
       <dependency org="zimbra" name="zm-client" rev="latest.integration" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally