### PR TITLE
Update httpclient version

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -13,9 +13,8 @@
       <dependency org="commons-io" name="commons-io" rev="1.4" />
       <dependency org="commons-codec" name="commons-codec" rev="1.7" />
       <dependency org="commons-lang" name="commons-lang" rev="2.6" />
-      <dependency org="commons-httpclient" name="commons-httpclient" rev="3.1" />
-      <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.2" />
-      <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5" />
+      <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.13" />
+      <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.5.13" />
       <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
       <!-- Local Requirements -->
       <dependency org="zimbra" name="zm-common" rev="latest.integration" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -14,7 +14,7 @@
       <dependency org="commons-codec" name="commons-codec" rev="1.7" />
       <dependency org="commons-lang" name="commons-lang" rev="2.6" />
       <dependency org="org.apache.httpcomponents" name="httpclient" rev="4.5.13" />
-      <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.5.13" />
+      <dependency org="org.apache.httpcomponents" name="httpcore" rev="4.4.5" />
       <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
       <!-- Local Requirements -->
       <dependency org="zimbra" name="zm-common" rev="latest.integration" />


### PR DESCRIPTION
Update httpclient version because of security vulnerability
Commons-httpclient is not necessary

[CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956)