### PR TITLE
Udpdate graphql version

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -6,7 +6,7 @@
       <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
       <dependency org="javax.ws.rs" name="javax.ws.rs-api" rev="2.0.1" />
       <!-- GraphQL Requirements -->
-      <dependency org="com.graphql-java" name="graphql-java" rev="9.3" />
+      <dependency org="com.graphql-java" name="graphql-java" rev="9.0" />
       <dependency org="io.leangen.graphql" name="spqr" rev="0.11.2"/>
       <!-- Common Requirements -->
       <dependency org="commons-collections" name="commons-collections" rev="3.2.2" />

--- a/ivy.xml
+++ b/ivy.xml
@@ -43,6 +43,6 @@
       <!-- jackson jars -->
       <dependency org="com.fasterxml.jackson.core" name="jackson-core" rev="2.10.1"/>
       <dependency org="com.fasterxml.jackson.core" name="jackson-annotations" rev="2.10.1"/>
-      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.10.1"/>
+      <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="2.13.3"/>
     </dependencies>
 </ivy-module>

--- a/ivy.xml
+++ b/ivy.xml
@@ -6,8 +6,8 @@
       <dependency org="javax.servlet" name="javax.servlet-api" rev="3.1.0" />
       <dependency org="javax.ws.rs" name="javax.ws.rs-api" rev="2.0.1" />
       <!-- GraphQL Requirements -->
-      <dependency org="com.graphql-java" name="graphql-java" rev="9.0" />
-      <dependency org="io.leangen.graphql" name="spqr" rev="0.9.7"/>
+      <dependency org="com.graphql-java" name="graphql-java" rev="9.3" />
+      <dependency org="io.leangen.graphql" name="spqr" rev="0.11.2"/>
       <!-- Common Requirements -->
       <dependency org="commons-collections" name="commons-collections" rev="3.2.2" />
       <dependency org="commons-io" name="commons-io" rev="1.4" />


### PR DESCRIPTION
Update spqr version because of security vulnerability
Update jackson-databind vers for same reasons 

[CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649)
[CVE-2020-3651813956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518)